### PR TITLE
staging: 2025-01-20

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -5,11 +5,11 @@
         "nixpkgs-lib": "nixpkgs-lib"
       },
       "locked": {
-        "lastModified": 1735774679,
-        "narHash": "sha256-soePLBazJk0qQdDVhdbM98vYdssfs3WFedcq+raipRI=",
+        "lastModified": 1736143030,
+        "narHash": "sha256-+hu54pAoLDEZT9pjHlqL9DNzWz0NbUn8NEAHP7PQPzU=",
         "owner": "hercules-ci",
         "repo": "flake-parts",
-        "rev": "f2f7418ce0ab4a5309a4596161d154cfc877af66",
+        "rev": "b905f6fc23a9051a6e1b741e1438dbfc0634c6de",
         "type": "github"
       },
       "original": {
@@ -25,11 +25,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1735774425,
-        "narHash": "sha256-C73gLFnEh8ZI0uDijUgCDWCd21T6I6tsaWgIBHcfAXg=",
+        "lastModified": 1736277415,
+        "narHash": "sha256-kPDXF6cIPsVqSK08XF5EC6KM7BdMnM9vtJDzsnf+lLU=",
         "owner": "nix-community",
         "repo": "home-manager",
-        "rev": "5f6aa268e419d053c3d5025da740e390b12ac936",
+        "rev": "5c4302313d9207f7ec0886d68f8ff4a3c71209a1",
         "type": "github"
       },
       "original": {
@@ -40,11 +40,11 @@
     },
     "nixos-hardware": {
       "locked": {
-        "lastModified": 1735388221,
-        "narHash": "sha256-e5IOgjQf0SZcFCEV/gMGrsI0gCJyqOKShBQU0iiM3Kg=",
+        "lastModified": 1736283893,
+        "narHash": "sha256-BG1FfTexFwNty5VhYjaQLMR6CMPfI3QRcaZrFQYu2EM=",
         "owner": "NixOS",
         "repo": "nixos-hardware",
-        "rev": "7c674c6734f61157e321db595dbfcd8523e04e19",
+        "rev": "4f339f6be2b61662f957c2ee9eda0fa597d8a6d6",
         "type": "github"
       },
       "original": {
@@ -55,11 +55,11 @@
     },
     "nixpkgs": {
       "locked": {
-        "lastModified": 1735471104,
-        "narHash": "sha256-0q9NGQySwDQc7RhAV2ukfnu7Gxa5/ybJ2ANT8DQrQrs=",
+        "lastModified": 1736012469,
+        "narHash": "sha256-/qlNWm/IEVVH7GfgAIyP6EsVZI6zjAx1cV5zNyrs+rI=",
         "owner": "NixOS",
         "repo": "nixpkgs",
-        "rev": "88195a94f390381c6afcdaa933c2f6ff93959cb4",
+        "rev": "8f3e1f807051e32d8c95cd12b9b421623850a34d",
         "type": "github"
       },
       "original": {

--- a/flake.lock
+++ b/flake.lock
@@ -25,11 +25,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1733484277,
-        "narHash": "sha256-i5ay20XsvpW91N4URET/nOc0VQWOAd4c4vbqYtcH8Rc=",
+        "lastModified": 1734093295,
+        "narHash": "sha256-hSwgGpcZtdDsk1dnzA0xj5cNaHgN9A99hRF/mxMtwS4=",
         "owner": "nix-community",
         "repo": "home-manager",
-        "rev": "d00c6f6d0ad16d598bf7e2956f52c1d9d5de3c3a",
+        "rev": "66c5d8b62818ec4c1edb3e941f55ef78df8141a8",
         "type": "github"
       },
       "original": {
@@ -40,11 +40,11 @@
     },
     "nixos-hardware": {
       "locked": {
-        "lastModified": 1733481457,
-        "narHash": "sha256-IS3bxa4N1VMSh3/P6vhEAHQZecQ3oAlKCDvzCQSO5Is=",
+        "lastModified": 1733861262,
+        "narHash": "sha256-+jjPup/ByS0LEVIrBbt7FnGugJgLeG9oc+ivFASYn2U=",
         "owner": "NixOS",
         "repo": "nixos-hardware",
-        "rev": "e563803af3526852b6b1d77107a81908c66a9fcf",
+        "rev": "cf737e2eba82b603f54f71b10cb8fd09d22ce3f5",
         "type": "github"
       },
       "original": {
@@ -55,11 +55,11 @@
     },
     "nixpkgs": {
       "locked": {
-        "lastModified": 1733392399,
-        "narHash": "sha256-kEsTJTUQfQFIJOcLYFt/RvNxIK653ZkTBIs4DG+cBns=",
+        "lastModified": 1734119587,
+        "narHash": "sha256-AKU6qqskl0yf2+JdRdD0cfxX4b9x3KKV5RqA6wijmPM=",
         "owner": "NixOS",
         "repo": "nixpkgs",
-        "rev": "d0797a04b81caeae77bcff10a9dde78bc17f5661",
+        "rev": "3566ab7246670a43abd2ffa913cc62dad9cdf7d5",
         "type": "github"
       },
       "original": {

--- a/flake.lock
+++ b/flake.lock
@@ -5,11 +5,11 @@
         "nixpkgs-lib": "nixpkgs-lib"
       },
       "locked": {
-        "lastModified": 1733312601,
-        "narHash": "sha256-4pDvzqnegAfRkPwO3wmwBhVi/Sye1mzps0zHWYnP88c=",
+        "lastModified": 1735774679,
+        "narHash": "sha256-soePLBazJk0qQdDVhdbM98vYdssfs3WFedcq+raipRI=",
         "owner": "hercules-ci",
         "repo": "flake-parts",
-        "rev": "205b12d8b7cd4802fbcb8e8ef6a0f1408781a4f9",
+        "rev": "f2f7418ce0ab4a5309a4596161d154cfc877af66",
         "type": "github"
       },
       "original": {
@@ -25,11 +25,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1734093295,
-        "narHash": "sha256-hSwgGpcZtdDsk1dnzA0xj5cNaHgN9A99hRF/mxMtwS4=",
+        "lastModified": 1735774425,
+        "narHash": "sha256-C73gLFnEh8ZI0uDijUgCDWCd21T6I6tsaWgIBHcfAXg=",
         "owner": "nix-community",
         "repo": "home-manager",
-        "rev": "66c5d8b62818ec4c1edb3e941f55ef78df8141a8",
+        "rev": "5f6aa268e419d053c3d5025da740e390b12ac936",
         "type": "github"
       },
       "original": {
@@ -40,11 +40,11 @@
     },
     "nixos-hardware": {
       "locked": {
-        "lastModified": 1733861262,
-        "narHash": "sha256-+jjPup/ByS0LEVIrBbt7FnGugJgLeG9oc+ivFASYn2U=",
+        "lastModified": 1735388221,
+        "narHash": "sha256-e5IOgjQf0SZcFCEV/gMGrsI0gCJyqOKShBQU0iiM3Kg=",
         "owner": "NixOS",
         "repo": "nixos-hardware",
-        "rev": "cf737e2eba82b603f54f71b10cb8fd09d22ce3f5",
+        "rev": "7c674c6734f61157e321db595dbfcd8523e04e19",
         "type": "github"
       },
       "original": {
@@ -55,11 +55,11 @@
     },
     "nixpkgs": {
       "locked": {
-        "lastModified": 1734119587,
-        "narHash": "sha256-AKU6qqskl0yf2+JdRdD0cfxX4b9x3KKV5RqA6wijmPM=",
+        "lastModified": 1735471104,
+        "narHash": "sha256-0q9NGQySwDQc7RhAV2ukfnu7Gxa5/ybJ2ANT8DQrQrs=",
         "owner": "NixOS",
         "repo": "nixpkgs",
-        "rev": "3566ab7246670a43abd2ffa913cc62dad9cdf7d5",
+        "rev": "88195a94f390381c6afcdaa933c2f6ff93959cb4",
         "type": "github"
       },
       "original": {
@@ -71,14 +71,14 @@
     },
     "nixpkgs-lib": {
       "locked": {
-        "lastModified": 1733096140,
-        "narHash": "sha256-1qRH7uAUsyQI7R1Uwl4T+XvdNv778H0Nb5njNrqvylY=",
+        "lastModified": 1735774519,
+        "narHash": "sha256-CewEm1o2eVAnoqb6Ml+Qi9Gg/EfNAxbRx1lANGVyoLI=",
         "type": "tarball",
-        "url": "https://github.com/NixOS/nixpkgs/archive/5487e69da40cbd611ab2cadee0b4637225f7cfae.tar.gz"
+        "url": "https://github.com/NixOS/nixpkgs/archive/e9b51731911566bbf7e4895475a87fe06961de0b.tar.gz"
       },
       "original": {
         "type": "tarball",
-        "url": "https://github.com/NixOS/nixpkgs/archive/5487e69da40cbd611ab2cadee0b4637225f7cfae.tar.gz"
+        "url": "https://github.com/NixOS/nixpkgs/archive/e9b51731911566bbf7e4895475a87fe06961de0b.tar.gz"
       }
     },
     "root": {

--- a/lib/default.nix
+++ b/lib/default.nix
@@ -10,10 +10,9 @@
   );
 
   mkModules = (modulesPath: { ... } @ extraArgs: {
-    imports = final.pipe modulesPath [
-      final.filesystem.listFilesRecursive
-      (final.filter (final.hasSuffix "module.nix"))
-      (map (mod:
+    imports = final.filesystem.listFilesRecursive modulesPath
+      |> final.filter (final.hasSuffix "module.nix")
+      |> map (mod:
       let
         imported = import mod;
       in {
@@ -22,12 +21,11 @@
           _file = mod; # better error reporting in the module system
         };
         __functionArgs = final.functionArgs imported;
-      }))
-    ];
-  });
+      });
+    });
                                                                                       
-  mkNixOSConfigurations = (system: list: final.pipe list [
-    (map ({ hostName, modules, ... } @ extraArgs: {
+  mkNixOSConfigurations = (system: list: list
+    |> map ({ hostName, modules, ... } @ extraArgs: {
       name = hostName;
       value = final.nixosSystem {
         specialArgs = {
@@ -42,19 +40,18 @@
           }
         ] ++ modules;
       } // (removeAttrs extraArgs [ "hostName" "modules" "specialArgs" ]);
-    }))
-    final.listToAttrs
-  ]);
+    })
+    |> final.listToAttrs
+  );
 
-  mkPackages = (pkgs: pkgsPath: final.pipe pkgsPath [
-    final.filesystem.listFilesRecursive
-    (final.filter (final.hasSuffix "package.nix"))
-    (map (drv: rec {
+  mkPackages = (pkgs: pkgsPath: final.filesystem.listFilesRecursive pkgsPath
+    |> final.filter (final.hasSuffix "package.nix")
+    |> map (drv: rec {
       name = final.getName value;
       value = pkgs.callPackage drv {};
-    }))
-    final.listToAttrs
-  ]);
+    })
+    |> final.listToAttrs
+  );
                                                                                       
   stripSystem = (system: flake:
   let

--- a/modules/common/toplevel/cachix/module.nix
+++ b/modules/common/toplevel/cachix/module.nix
@@ -1,0 +1,25 @@
+{
+  config,
+  lib,
+  ...
+}:
+let
+  path = lib.splitString "." <| "my.toplevel.cachix";
+  commonOpts = lib.mkOption {
+    default = [];
+
+    type = with lib.types; listOf package;
+  };
+in {
+  options = lib.setAttrByPath path commonOpts;
+
+  config = {
+    my.toplevel.cachix = lib.attrValues config.home-manager.users
+      |> map (config: config.my.toplevel.cachix)
+      |> lib.flatten;
+
+    home-manager.sharedModules = [{
+      options = lib.setAttrByPath path commonOpts;
+    }];
+  };
+}

--- a/modules/home-manager/programs/cheat/module.nix
+++ b/modules/home-manager/programs/cheat/module.nix
@@ -23,6 +23,9 @@ in {
   };
 
   config = lib.mkIf cfg.enable {
+    my.toplevel.cachix = [
+      config.xdg.configFile."cheat/cheatsheets/community".source ];
+
     home.packages = [ cfg.package ];
 
     my.programs.cheat.settings = {

--- a/modules/home-manager/programs/direnv/module.nix
+++ b/modules/home-manager/programs/direnv/module.nix
@@ -44,6 +44,8 @@ in {
   };
 
   config = lib.mkIf cfg.enable {
+    my.toplevel.cachix = [ cfg.package ];
+
     programs.direnv = {
       enable = true;
       package = cfg.package;

--- a/modules/home-manager/programs/inxi/module.nix
+++ b/modules/home-manager/programs/inxi/module.nix
@@ -18,6 +18,8 @@ in {
   };
 
   config = lib.mkIf cfg.enable {
+    my.toplevel.cachix = [ cfg.package ];
+
     home.packages = [ cfg.package ];
   };
 }

--- a/modules/home-manager/programs/inxi/module.nix
+++ b/modules/home-manager/programs/inxi/module.nix
@@ -1,0 +1,23 @@
+{
+  config,
+  lib,
+  pkgs,
+  ...
+}:
+let
+  path = lib.splitString "." <| "my.programs.inxi";
+  cfg = lib.getAttrFromPath path config;
+in {
+  options = lib.setAttrByPath path {
+    enable = lib.mkDefaultEnableOption "inxi";
+    package = lib.mkOption {
+      default = pkgs.callPackage ./package.nix {};
+
+      type = with lib.types; package;
+    };
+  };
+
+  config = lib.mkIf cfg.enable {
+    home.packages = [ cfg.package ];
+  };
+}

--- a/modules/home-manager/programs/inxi/package.nix
+++ b/modules/home-manager/programs/inxi/package.nix
@@ -1,0 +1,46 @@
+{
+  lib,
+  symlinkJoin,
+  makeWrapper,
+
+  inxi,
+
+  bluez,
+  bluez-tools,
+  busybox,
+  dig,
+  dmidecode,
+  lm_sensors,
+  smartmontools,
+  toybox,
+  usbutils,
+  virtualgl,
+  vulkan-tools,
+  wayland-utils,
+}:
+let
+  runtimeInputs = [
+    bluez
+    bluez-tools
+    busybox
+    dig
+    dmidecode
+    lm_sensors
+    smartmontools
+    toybox
+    usbutils
+    virtualgl
+    vulkan-tools
+    wayland-utils
+  ];
+in symlinkJoin {
+  name = "inxi";
+  paths = [ inxi ];
+
+  nativeBuildInputs = [ makeWrapper ];
+
+  postBuild = ''
+    wrapProgram $out/bin/inxi \
+      --prefix PATH : ${lib.makeBinPath runtimeInputs}
+  '';
+}

--- a/modules/home-manager/programs/microsoft-edge/module.nix
+++ b/modules/home-manager/programs/microsoft-edge/module.nix
@@ -33,6 +33,8 @@ in {
 
   config = lib.mkIf cfg.enable (lib.mkMerge [
     {
+      my.toplevel.cachix = [ cfg.package ];
+
       my.persist.directories = [
         "${cfg.userDataDir}"
         "~/.cache/microsoft-edge"

--- a/modules/home-manager/programs/neovim/module.nix
+++ b/modules/home-manager/programs/neovim/module.nix
@@ -64,6 +64,8 @@ in {
   };
 
   config = lib.mkIf cfg.enable {
+    my.toplevel.cachix = [ cfg.package ];
+
     my.persist.directories = [
       "~/.local/state/nvim"
     ];

--- a/modules/home-manager/programs/nix-index/module.nix
+++ b/modules/home-manager/programs/nix-index/module.nix
@@ -24,6 +24,8 @@ in {
   };
 
   config = lib.mkIf cfg.enable {
+    my.toplevel.cachix = [ cfg.package ];
+
     my.persist.directories = [ "~/.cache/nix-index" ];
 
     programs.command-not-found.enable = lib.mkForce false;

--- a/modules/home-manager/programs/patool/module.nix
+++ b/modules/home-manager/programs/patool/module.nix
@@ -19,6 +19,8 @@ in {
   };
 
   config = lib.mkIf cfg.enable {
+    my.toplevel.cachix = [ cfg.package ];
+
     home.packages = [ cfg.package ];
   };
 }

--- a/modules/home-manager/programs/patool/package.nix
+++ b/modules/home-manager/programs/patool/package.nix
@@ -38,12 +38,6 @@
 let
   stdenv = gcc13Stdenv;
 
-  patool' = (builtins.getFlake "github:NixOS/nixpkgs/7fa1a3c6b3d22f5e53bb765518a749847a25bb65").legacyPackages.${stdenv.system}.patool;
-
-  arj' = arj.override {
-    inherit stdenv;
-  };
-
   lha' = lha.override {
     inherit stdenv;
   };
@@ -53,7 +47,7 @@ let
   };
 in symlinkJoin {
   name = "patool";
-  paths = [ patool' ];
+  paths = [ patool ];
 
   nativeBuildInputs = [ makeWrapper ];
 
@@ -61,7 +55,7 @@ in symlinkJoin {
     wrapProgram $out/bin/patool \
       --prefix PATH : ${lib.makeBinPath [
         archiver
-        arj'
+        arj
         bintools
         bzip2
         bzip3

--- a/modules/home-manager/programs/patool/package.nix
+++ b/modules/home-manager/programs/patool/package.nix
@@ -2,6 +2,7 @@
   lib,
   symlinkJoin,
   makeWrapper,
+  gcc13Stdenv,
 
   patool,
 
@@ -34,9 +35,25 @@
   zpaq,
   zstd,
 }:
-symlinkJoin {
+let
+  stdenv = gcc13Stdenv;
+
+  patool' = (builtins.getFlake "github:NixOS/nixpkgs/7fa1a3c6b3d22f5e53bb765518a749847a25bb65").legacyPackages.${stdenv.system}.patool;
+
+  arj' = arj.override {
+    inherit stdenv;
+  };
+
+  lha' = lha.override {
+    inherit stdenv;
+  };
+
+  rzip' = rzip.override {
+    inherit stdenv;
+  };
+in symlinkJoin {
   name = "patool";
-  paths = [ patool ];
+  paths = [ patool' ];
 
   nativeBuildInputs = [ makeWrapper ];
 
@@ -44,7 +61,7 @@ symlinkJoin {
     wrapProgram $out/bin/patool \
       --prefix PATH : ${lib.makeBinPath [
         archiver
-        arj
+        arj'
         bintools
         bzip2
         bzip3
@@ -55,7 +72,7 @@ symlinkJoin {
         gnutar
         gzip
         lcab
-        lha
+        lha'
         lrzip
         lz4
         lzip
@@ -64,7 +81,7 @@ symlinkJoin {
         ncompress
         p7zip
         rar
-        rzip
+        rzip'
         sharutils
         unar
         xz

--- a/modules/home-manager/programs/vscode/module.nix
+++ b/modules/home-manager/programs/vscode/module.nix
@@ -41,6 +41,8 @@ in {
   };
 
   config = lib.mkIf cfg.enable {
+    my.toplevel.cachix = [ cfg.package ];
+
     home.packages = [ cfg.package ];
 
     xdg.configFile."Code/User/settings.json".source = formats-json.generate "settings-json" cfg.config;

--- a/modules/nixos/programs/nix/module.nix
+++ b/modules/nixos/programs/nix/module.nix
@@ -14,6 +14,10 @@ let
 in {
   config = lib.mkIf config.nix.enable (lib.mkMerge [
     {
+      # Cache our nix wrapper via cachix. This isn't strictly necessary
+      # since the build is extremely small and fast, but why not.
+      my.toplevel.cachix = [ config.nix.package ];
+
       # Use github:viperML/nh as our "nix wrapper" program.
       programs.nh.enable = true;
 

--- a/modules/nixos/programs/nix/module.nix
+++ b/modules/nixos/programs/nix/module.nix
@@ -18,6 +18,13 @@ in {
       # since the build is extremely small and fast, but why not.
       my.toplevel.cachix = [ config.nix.package ];
 
+      # Instruct the daemon to use `/var/tmp` as the TMPDIR instead of `/tmp`.
+      # This is because `/tmp` can be a tmpfs (and honestly should). `/var/tmp`
+      # is designed to contain persistent, yet temporary files, a definition
+      # that fits Nix's usage of the TMPDIR perfectly.
+      my.persist.directories = [ "/var/tmp" ];
+      systemd.services.nix-daemon.environment.TMPDIR = "/var/tmp";
+
       # Use github:viperML/nh as our "nix wrapper" program.
       programs.nh.enable = true;
 

--- a/modules/nixos/programs/nix/module.nix
+++ b/modules/nixos/programs/nix/module.nix
@@ -23,7 +23,7 @@ in {
 
       # Wrap the official nix binary with a snippet to allow
       # rapid repl access to `pkgs.*` and `lib.*` attributes.
-      nix.package = pkgs.callPackage ./package.nix { nix = pkgs.lix; };
+      nix.package = pkgs.callPackage ./package.nix { nix = pkgs.nixVersions.git; };
     }
     {
       # Throttle the nix-daemon so it doesn't consume
@@ -91,19 +91,21 @@ in {
           builders-use-substitutes = true;
 
           connect-timeout = 5;
-          cores = 2;
+          cores = 2; # cores *per* derivation (that support parallel builds)
 
           debugger-on-trace = true;
           # debugger-on-warn = true;
           download-attempts = 2;
-          eval-cache = true;
 
           # It's useful to know when a substitute is failing!
+          # Can use `--fallback` on the CLI when needed.
           fallback = false;
 
           # Improve the chances of the store surviving a random crash.
           fsync-metadata = true;
-          # fsync-store-paths = true; TODO: on next Lix release
+          fsync-store-paths = true;
+
+          http-connections = 0; # unlimited connections!!
 
           # Keeping these is very useful for development.
           keep-build-log = true;
@@ -111,16 +113,21 @@ in {
           keep-failed = true;
           keep-outputs = true;
 
-          max-jobs = "auto";
+          log-lines = 100;
+
+          max-jobs = "auto"; # no. of derivations in parallel (auto = all cores)
           min-free = 10 * 1024 * 1024 * 1024;
 
           preallocate-contents = false; # Unnecessary on modern I/O
+          # TODO: force a cachix upload after each build?
+          # post-build-hook = "";
+          print-missing = false; # I don't really need to see this.
 
           # Never allow a non-sandboxed build
           sandbox-fallback = false;
 
           show-trace = true;
-          sync-before-registering = true;
+          sync-before-registering = true; # TODO: needed with fsync options?
 
           trace-verbose = true;
           trusted-users = [
@@ -152,7 +159,7 @@ in {
             # Some interesting features.
             # "fetch-closures"
             "no-url-literals"
-            "pipe-operator"
+            "pipe-operators"
           ];
         }
       ];

--- a/modules/nixos/system/audio/pipewire/module.nix
+++ b/modules/nixos/system/audio/pipewire/module.nix
@@ -13,7 +13,7 @@ in {
   config = lib.mkIf cfg.enable (lib.mkMerge [
     {
       # Kill PulseAudio and ALSA stuff
-      hardware.pulseaudio.enable = lib.mkForce false;
+      services.pulseaudio.enable = lib.mkForce false;
       hardware.alsa.enablePersistence = false; # https://github.com/NixOS/nixpkgs/issues/330606
     }
     {

--- a/modules/nixos/system/boot/systemd-boot/module.nix
+++ b/modules/nixos/system/boot/systemd-boot/module.nix
@@ -25,7 +25,7 @@ in {
         editor = cfg.editor;
       };
     }
-    (lib.mkIf cfg.silent {
+    (lib.mkIf cfg.silent rec {
       # https://wiki.archlinux.org/title/Silent_boot
       boot.consoleLogLevel = 3;
       boot.initrd.verbose = false;
@@ -35,7 +35,7 @@ in {
       boot.kernelParams = [
         "quiet"
         "systemd.show_status=auto"
-        "udev.log_level=${toString config.boot.consoleLogLevel}"
+        "udev.log_level=${toString boot.consoleLogLevel}"
       ];
     })
   ]);

--- a/modules/nixos/system/mounts/swap/module.nix
+++ b/modules/nixos/system/mounts/swap/module.nix
@@ -26,7 +26,6 @@ in {
         enable = true;
         memoryPercent = 150; # https://unix.stackexchange.com/a/596929
         priority = 100;
-        # TODO: writebackDevice?
       };
     })
   ];

--- a/modules/nixos/system/mounts/tmp/module.nix
+++ b/modules/nixos/system/mounts/tmp/module.nix
@@ -12,10 +12,6 @@ in {
 
   config = lib.mkMerge [
     (lib.mkIf cfg.enableTmpfs {
-      # Force the Nix builder into a sane TMPDIR
-      my.persist.directories = [ "/var/tmp" ];
-      systemd.services.nix-daemon.environment.TMPDIR = "/var/tmp";
-
       # Use tmpfs for /tmp as it's just easier to use.
       # Not using this means that cleaning on boot can
       # take a few seconds, which is wasteful.

--- a/nix/nixosModules/default.nix
+++ b/nix/nixosModules/default.nix
@@ -20,8 +20,13 @@ in {
       ../../users
     ];
 
-    config.home-manager.sharedModules = [
-      (lib.mkModules ../../modules/home-manager {})
-    ];
+    config.home-manager = {
+      useGlobalPkgs = true;
+      useUserPackages = true;
+
+      sharedModules = [
+        (lib.mkModules ../../modules/home-manager {})
+      ];
+    };
   };
 }

--- a/nix/packages/cachix.nix
+++ b/nix/packages/cachix.nix
@@ -8,17 +8,7 @@
     packages = self.nixosConfigurations
       |> lib.filterAttrs (_: value: value.pkgs.system == pkgs.system)
       |> lib.mapAttrs (name: value: pkgs.linkFarmFromDrvs "cachix-${name}" (
-        # For modules/nixos
-        (lib.attrValues value.config.my
-        |> lib.filter (x: x ? package)
-        |> map (x: x.package))
-        ++ 
-        # For modules/home-manager
-        (lib.attrValues value.config.home-manager.users
-        |> map (x: lib.attrValues x.my.programs)
-        |> lib.concatLists
-        |> lib.filter (x: x ? package)
-        |> map (x: x.package))
+        value.config.my.toplevel.cachix
       )
     );
   };


### PR DESCRIPTION
Happy New Years! This has been a late update due to being busy with real life commitments. I hope to slowly return to improving this and my other projects.

#### Things Done
1. (https://github.com/Frontear/dotfiles/commit/77b55f76bcbed0a32022e3e92ea6ac0f6c7fd193) Bump the `flake.lock` revisions, no breaking changes that required fixing.
2. (https://github.com/Frontear/dotfiles/commit/88b1c168abebf90f42db80ca73d3b1b76113a929) Introduced `inxi` for system information and diagnostics. The application is wrapped with the majority of important tooling that allows it to work as well as possible. Further may be required and can be checked via `inxi --recommends`.
3. (https://github.com/Frontear/dotfiles/commit/ccacbb4cab3c1c634d641c89439b727af9327489) Replace `lib.pipe` with the actual pipe operator experimental feature. This also brought a massive improvement to the cachix packages expression, which now leverages the flake-parts `perSystem` rather than iterating over all flake outputs directly.
4. (https://github.com/Frontear/dotfiles/commit/cfbd3969a525c23409a2b9ae5caddcff9f2e5cc5) Bump `flake.lock` and fix issues related to stdenv changes. Nixpkgs recently bumped GCC from 13 to 14. This broke a lot of packages since the stdenv on linux uses gcc by default. The simplest fix I had at the time was to simply override each package to a stdenv using gcc 13. Some of those pins are still there due to no fix on Nixpkgs and/or upstream. I will look at these more closely next release cycle.
5. (https://github.com/Frontear/dotfiles/commit/68440938aeb2b3a59f8b28039d0b9a59fa2de625) Cleanup the entirety of the cachix nix expression through usage of a top-level attribute. This attribute, accessible at `my.toplevel.cachix = [ ... ]`, can track all the important derivations, even if they are not directly part of a `.package` output. This is significantly more flexible but requires manual intervention to ensure nothing is missed. I did a fairly comprehensive sweep over the repository and picked out the things that should be cached, mainly the ones that have local overrides. This can be periodically checked again, perhaps with some automated way in the future.
6. (https://github.com/Frontear/dotfiles/commit/1c5206087ad302e4d97aa3717a9e551187dea5bd) Bump `flake.lock` again, with no major breakages. If anything, this actually fixed some of the GCC 14 bump changes from the previous upgrade.
7. (https://github.com/Frontear/dotfiles/commit/4657d3a092b50dddf83e480e63700da647a96d61) Remove Lix and replace it with bleeding-edge Nix. I won't go into much detail especially because I have never actively participated in the Lix community, and due to my busyness, I have not been very active in the Nix community either. Suffice it to say that I do not want to contribute further to dividing the Nix community. I really love what we have and it's extremely disheartening to see everyone tearing each other apart over their differences. Don't get me wrong, I have extremely strong opinions against Eelco's behaviour, DetSys, Anduril, and the rest, but I also believe that there are truly better ways to move forward than just to "fork and disconnect" (to put it extremely tersely).
8. (https://github.com/Frontear/dotfiles/commit/44c1976a4f30122c7a0c57951758e56e5af3eef9) Small random fixes across various nitpicks and modules. The declaration around changing the Nix daemon's `TMPDIR` was moved into the nix module itself, the recommendation of trying to setup a writeback device for zram was removed since it would functionally have no benefit (still uses the same amount of RAM, just on a difference vdev), and finally I am deciding to use `rec` for an extremely small systemd-boot module block, simply because I don't think traversing `config` for it is necessary. I don't really want to have extremely anti-* opinions on the usage of `with` and `rec`, like some others, since they are valuable in controlled and small nix expressions.