### PR TITLE
staging: 2025-03-21

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -25,11 +25,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1739470101,
-        "narHash": "sha256-NxNe32VB4XI/xIXrsKmIfrcgtEx5r/5s52pL3CpEcA4=",
+        "lastModified": 1740432748,
+        "narHash": "sha256-BCeFtoJ/+LrZc03viRJWHfzAqqG8gPu/ikZeurv05xs=",
         "owner": "nix-community",
         "repo": "home-manager",
-        "rev": "5031c6d2978109336637977c165f82aa49fa16a7",
+        "rev": "c12dcc9b61429b2ad437a7d4974399ad8f910319",
         "type": "github"
       },
       "original": {
@@ -40,11 +40,11 @@
     },
     "nixos-hardware": {
       "locked": {
-        "lastModified": 1738816619,
-        "narHash": "sha256-5yRlg48XmpcX5b5HesdGMOte+YuCy9rzQkJz+imcu6I=",
+        "lastModified": 1740387674,
+        "narHash": "sha256-pGk/aA0EBvI6o4DeuZsr05Ig/r4uMlSaf5EWUZEWM10=",
         "owner": "NixOS",
         "repo": "nixos-hardware",
-        "rev": "2eccff41bab80839b1d25b303b53d339fbb07087",
+        "rev": "d58f642ddb23320965b27beb0beba7236e9117b5",
         "type": "github"
       },
       "original": {
@@ -55,11 +55,11 @@
     },
     "nixpkgs": {
       "locked": {
-        "lastModified": 1739446958,
-        "narHash": "sha256-+/bYK3DbPxMIvSL4zArkMX0LQvS7rzBKXnDXLfKyRVc=",
+        "lastModified": 1740367490,
+        "narHash": "sha256-WGaHVAjcrv+Cun7zPlI41SerRtfknGQap281+AakSAw=",
         "owner": "NixOS",
         "repo": "nixpkgs",
-        "rev": "2ff53fe64443980e139eaa286017f53f88336dd0",
+        "rev": "0196c0175e9191c474c26ab5548db27ef5d34b05",
         "type": "github"
       },
       "original": {

--- a/flake.lock
+++ b/flake.lock
@@ -5,11 +5,11 @@
         "nixpkgs-lib": "nixpkgs-lib"
       },
       "locked": {
-        "lastModified": 1736143030,
-        "narHash": "sha256-+hu54pAoLDEZT9pjHlqL9DNzWz0NbUn8NEAHP7PQPzU=",
+        "lastModified": 1738453229,
+        "narHash": "sha256-7H9XgNiGLKN1G1CgRh0vUL4AheZSYzPm+zmZ7vxbJdo=",
         "owner": "hercules-ci",
         "repo": "flake-parts",
-        "rev": "b905f6fc23a9051a6e1b741e1438dbfc0634c6de",
+        "rev": "32ea77a06711b758da0ad9bd6a844c5740a87abd",
         "type": "github"
       },
       "original": {
@@ -25,11 +25,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1737762889,
-        "narHash": "sha256-5HGG09bh/Yx0JA8wtBMAzt0HMCL1bYZ93x4IqzVExio=",
+        "lastModified": 1739470101,
+        "narHash": "sha256-NxNe32VB4XI/xIXrsKmIfrcgtEx5r/5s52pL3CpEcA4=",
         "owner": "nix-community",
         "repo": "home-manager",
-        "rev": "daf04c5950b676f47a794300657f1d3d14c1a120",
+        "rev": "5031c6d2978109336637977c165f82aa49fa16a7",
         "type": "github"
       },
       "original": {
@@ -40,11 +40,11 @@
     },
     "nixos-hardware": {
       "locked": {
-        "lastModified": 1737751639,
-        "narHash": "sha256-ZEbOJ9iT72iwqXsiEMbEa8wWjyFvRA9Ugx8utmYbpz4=",
+        "lastModified": 1738816619,
+        "narHash": "sha256-5yRlg48XmpcX5b5HesdGMOte+YuCy9rzQkJz+imcu6I=",
         "owner": "NixOS",
         "repo": "nixos-hardware",
-        "rev": "dfad538f751a5aa5d4436d9781ab27a6128ec9d4",
+        "rev": "2eccff41bab80839b1d25b303b53d339fbb07087",
         "type": "github"
       },
       "original": {
@@ -55,11 +55,11 @@
     },
     "nixpkgs": {
       "locked": {
-        "lastModified": 1737885589,
-        "narHash": "sha256-Zf0hSrtzaM1DEz8//+Xs51k/wdSajticVrATqDrfQjg=",
+        "lastModified": 1739446958,
+        "narHash": "sha256-+/bYK3DbPxMIvSL4zArkMX0LQvS7rzBKXnDXLfKyRVc=",
         "owner": "NixOS",
         "repo": "nixpkgs",
-        "rev": "852ff1d9e153d8875a83602e03fdef8a63f0ecf8",
+        "rev": "2ff53fe64443980e139eaa286017f53f88336dd0",
         "type": "github"
       },
       "original": {
@@ -71,14 +71,14 @@
     },
     "nixpkgs-lib": {
       "locked": {
-        "lastModified": 1735774519,
-        "narHash": "sha256-CewEm1o2eVAnoqb6Ml+Qi9Gg/EfNAxbRx1lANGVyoLI=",
+        "lastModified": 1738452942,
+        "narHash": "sha256-vJzFZGaCpnmo7I6i416HaBLpC+hvcURh/BQwROcGIp8=",
         "type": "tarball",
-        "url": "https://github.com/NixOS/nixpkgs/archive/e9b51731911566bbf7e4895475a87fe06961de0b.tar.gz"
+        "url": "https://github.com/NixOS/nixpkgs/archive/072a6db25e947df2f31aab9eccd0ab75d5b2da11.tar.gz"
       },
       "original": {
         "type": "tarball",
-        "url": "https://github.com/NixOS/nixpkgs/archive/e9b51731911566bbf7e4895475a87fe06961de0b.tar.gz"
+        "url": "https://github.com/NixOS/nixpkgs/archive/072a6db25e947df2f31aab9eccd0ab75d5b2da11.tar.gz"
       }
     },
     "root": {

--- a/flake.lock
+++ b/flake.lock
@@ -25,11 +25,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1736277415,
-        "narHash": "sha256-kPDXF6cIPsVqSK08XF5EC6KM7BdMnM9vtJDzsnf+lLU=",
+        "lastModified": 1737762889,
+        "narHash": "sha256-5HGG09bh/Yx0JA8wtBMAzt0HMCL1bYZ93x4IqzVExio=",
         "owner": "nix-community",
         "repo": "home-manager",
-        "rev": "5c4302313d9207f7ec0886d68f8ff4a3c71209a1",
+        "rev": "daf04c5950b676f47a794300657f1d3d14c1a120",
         "type": "github"
       },
       "original": {
@@ -40,11 +40,11 @@
     },
     "nixos-hardware": {
       "locked": {
-        "lastModified": 1736283893,
-        "narHash": "sha256-BG1FfTexFwNty5VhYjaQLMR6CMPfI3QRcaZrFQYu2EM=",
+        "lastModified": 1737751639,
+        "narHash": "sha256-ZEbOJ9iT72iwqXsiEMbEa8wWjyFvRA9Ugx8utmYbpz4=",
         "owner": "NixOS",
         "repo": "nixos-hardware",
-        "rev": "4f339f6be2b61662f957c2ee9eda0fa597d8a6d6",
+        "rev": "dfad538f751a5aa5d4436d9781ab27a6128ec9d4",
         "type": "github"
       },
       "original": {
@@ -55,11 +55,11 @@
     },
     "nixpkgs": {
       "locked": {
-        "lastModified": 1736012469,
-        "narHash": "sha256-/qlNWm/IEVVH7GfgAIyP6EsVZI6zjAx1cV5zNyrs+rI=",
+        "lastModified": 1737885589,
+        "narHash": "sha256-Zf0hSrtzaM1DEz8//+Xs51k/wdSajticVrATqDrfQjg=",
         "owner": "NixOS",
         "repo": "nixpkgs",
-        "rev": "8f3e1f807051e32d8c95cd12b9b421623850a34d",
+        "rev": "852ff1d9e153d8875a83602e03fdef8a63f0ecf8",
         "type": "github"
       },
       "original": {

--- a/flake.lock
+++ b/flake.lock
@@ -5,11 +5,11 @@
         "nixpkgs-lib": "nixpkgs-lib"
       },
       "locked": {
-        "lastModified": 1740872218,
-        "narHash": "sha256-ZaMw0pdoUKigLpv9HiNDH2Pjnosg7NBYMJlHTIsHEUo=",
+        "lastModified": 1741352980,
+        "narHash": "sha256-+u2UunDA4Cl5Fci3m7S643HzKmIDAe+fiXrLqYsR2fs=",
         "owner": "hercules-ci",
         "repo": "flake-parts",
-        "rev": "3876f6b87db82f33775b1ef5ea343986105db764",
+        "rev": "f4330d22f1c5d2ba72d3d22df5597d123fdb60a9",
         "type": "github"
       },
       "original": {
@@ -25,11 +25,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1741056285,
-        "narHash": "sha256-/JKDMVqq8PIqcGonBVKbKq1SooV3kzGmv+cp3rKAgPA=",
+        "lastModified": 1742588233,
+        "narHash": "sha256-Fi5g8H5FXMSRqy+mU6gPG0v+C9pzjYbkkiePtz8+PpA=",
         "owner": "nix-community",
         "repo": "home-manager",
-        "rev": "70fbbf05a5594b0a72124ab211bff1d502c89e3f",
+        "rev": "296ddc64627f4a6a4eb447852d7346b9dd16197d",
         "type": "github"
       },
       "original": {
@@ -40,11 +40,11 @@
     },
     "nixos-hardware": {
       "locked": {
-        "lastModified": 1740646007,
-        "narHash": "sha256-dMReDQobS3kqoiUCQIYI9c0imPXRZnBubX20yX/G5LE=",
+        "lastModified": 1742376361,
+        "narHash": "sha256-VFMgJkp/COvkt5dnkZB4D2szVdmF6DGm5ZdVvTUy61c=",
         "owner": "NixOS",
         "repo": "nixos-hardware",
-        "rev": "009b764ac98a3602d41fc68072eeec5d24fc0e49",
+        "rev": "daaae13dff0ecc692509a1332ff9003d9952d7a9",
         "type": "github"
       },
       "original": {
@@ -55,11 +55,11 @@
     },
     "nixpkgs": {
       "locked": {
-        "lastModified": 1741010256,
-        "narHash": "sha256-WZNlK/KX7Sni0RyqLSqLPbK8k08Kq7H7RijPJbq9KHM=",
+        "lastModified": 1742422364,
+        "narHash": "sha256-mNqIplmEohk5jRkqYqG19GA8MbQ/D4gQSK0Mu4LvfRQ=",
         "owner": "NixOS",
         "repo": "nixpkgs",
-        "rev": "ba487dbc9d04e0634c64e3b1f0d25839a0a68246",
+        "rev": "a84ebe20c6bc2ecbcfb000a50776219f48d134cc",
         "type": "github"
       },
       "original": {
@@ -71,14 +71,17 @@
     },
     "nixpkgs-lib": {
       "locked": {
-        "lastModified": 1740872140,
-        "narHash": "sha256-3wHafybyRfpUCLoE8M+uPVZinImg3xX+Nm6gEfN3G8I=",
-        "type": "tarball",
-        "url": "https://github.com/NixOS/nixpkgs/archive/6d3702243441165a03f699f64416f635220f4f15.tar.gz"
+        "lastModified": 1740877520,
+        "narHash": "sha256-oiwv/ZK/2FhGxrCkQkB83i7GnWXPPLzoqFHpDD3uYpk=",
+        "owner": "nix-community",
+        "repo": "nixpkgs.lib",
+        "rev": "147dee35aab2193b174e4c0868bd80ead5ce755c",
+        "type": "github"
       },
       "original": {
-        "type": "tarball",
-        "url": "https://github.com/NixOS/nixpkgs/archive/6d3702243441165a03f699f64416f635220f4f15.tar.gz"
+        "owner": "nix-community",
+        "repo": "nixpkgs.lib",
+        "type": "github"
       }
     },
     "root": {

--- a/flake.lock
+++ b/flake.lock
@@ -5,11 +5,11 @@
         "nixpkgs-lib": "nixpkgs-lib"
       },
       "locked": {
-        "lastModified": 1738453229,
-        "narHash": "sha256-7H9XgNiGLKN1G1CgRh0vUL4AheZSYzPm+zmZ7vxbJdo=",
+        "lastModified": 1740872218,
+        "narHash": "sha256-ZaMw0pdoUKigLpv9HiNDH2Pjnosg7NBYMJlHTIsHEUo=",
         "owner": "hercules-ci",
         "repo": "flake-parts",
-        "rev": "32ea77a06711b758da0ad9bd6a844c5740a87abd",
+        "rev": "3876f6b87db82f33775b1ef5ea343986105db764",
         "type": "github"
       },
       "original": {
@@ -25,11 +25,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1740432748,
-        "narHash": "sha256-BCeFtoJ/+LrZc03viRJWHfzAqqG8gPu/ikZeurv05xs=",
+        "lastModified": 1741056285,
+        "narHash": "sha256-/JKDMVqq8PIqcGonBVKbKq1SooV3kzGmv+cp3rKAgPA=",
         "owner": "nix-community",
         "repo": "home-manager",
-        "rev": "c12dcc9b61429b2ad437a7d4974399ad8f910319",
+        "rev": "70fbbf05a5594b0a72124ab211bff1d502c89e3f",
         "type": "github"
       },
       "original": {
@@ -40,11 +40,11 @@
     },
     "nixos-hardware": {
       "locked": {
-        "lastModified": 1740387674,
-        "narHash": "sha256-pGk/aA0EBvI6o4DeuZsr05Ig/r4uMlSaf5EWUZEWM10=",
+        "lastModified": 1740646007,
+        "narHash": "sha256-dMReDQobS3kqoiUCQIYI9c0imPXRZnBubX20yX/G5LE=",
         "owner": "NixOS",
         "repo": "nixos-hardware",
-        "rev": "d58f642ddb23320965b27beb0beba7236e9117b5",
+        "rev": "009b764ac98a3602d41fc68072eeec5d24fc0e49",
         "type": "github"
       },
       "original": {
@@ -55,11 +55,11 @@
     },
     "nixpkgs": {
       "locked": {
-        "lastModified": 1740367490,
-        "narHash": "sha256-WGaHVAjcrv+Cun7zPlI41SerRtfknGQap281+AakSAw=",
+        "lastModified": 1741010256,
+        "narHash": "sha256-WZNlK/KX7Sni0RyqLSqLPbK8k08Kq7H7RijPJbq9KHM=",
         "owner": "NixOS",
         "repo": "nixpkgs",
-        "rev": "0196c0175e9191c474c26ab5548db27ef5d34b05",
+        "rev": "ba487dbc9d04e0634c64e3b1f0d25839a0a68246",
         "type": "github"
       },
       "original": {
@@ -71,14 +71,14 @@
     },
     "nixpkgs-lib": {
       "locked": {
-        "lastModified": 1738452942,
-        "narHash": "sha256-vJzFZGaCpnmo7I6i416HaBLpC+hvcURh/BQwROcGIp8=",
+        "lastModified": 1740872140,
+        "narHash": "sha256-3wHafybyRfpUCLoE8M+uPVZinImg3xX+Nm6gEfN3G8I=",
         "type": "tarball",
-        "url": "https://github.com/NixOS/nixpkgs/archive/072a6db25e947df2f31aab9eccd0ab75d5b2da11.tar.gz"
+        "url": "https://github.com/NixOS/nixpkgs/archive/6d3702243441165a03f699f64416f635220f4f15.tar.gz"
       },
       "original": {
         "type": "tarball",
-        "url": "https://github.com/NixOS/nixpkgs/archive/072a6db25e947df2f31aab9eccd0ab75d5b2da11.tar.gz"
+        "url": "https://github.com/NixOS/nixpkgs/archive/6d3702243441165a03f699f64416f635220f4f15.tar.gz"
       }
     },
     "root": {

--- a/hosts/iso/default.nix
+++ b/hosts/iso/default.nix
@@ -1,4 +1,8 @@
 {
+  lib,
+  ...
+}:
+{
   imports = [
     ./configuration.nix
     ./hardware-configuration.nix
@@ -6,7 +10,7 @@
 
   config = {
     isoImage = {
-      isoBaseName = "frontear-nixos";
+      isoBaseName = lib.mkForce "frontear-nixos";
       squashfsCompression = "lz4";
     };
   };

--- a/hosts/laptop/configuration.nix
+++ b/hosts/laptop/configuration.nix
@@ -23,6 +23,14 @@
     # Enable a desktop environment
     my.desktops.sway.enable = true;
 
+    # Grab the `libimobiledevice` suite of tools.
+    services.usbmuxd.enable = true;
+    environment.systemPackages = with pkgs; [
+      ifuse
+      idevicerestore
+      libimobiledevice
+    ];
+
     # Set locale, keymap and timezone
     console.keyMap = "us";
     i18n.defaultLocale = "en_CA.UTF-8";

--- a/modules/home-manager/programs/patool/package.nix
+++ b/modules/home-manager/programs/patool/package.nix
@@ -6,8 +6,7 @@
 
   patool,
 
-  # TODO: unace, unadf, unalz, xdms, shorten, zoo
-  archiver,
+  # TODO: arc, unace, unadf, unalz, xdms, shorten, zoo
   arj,
   bintools,
   bzip2,
@@ -54,7 +53,6 @@ in symlinkJoin {
   postBuild = ''
     wrapProgram $out/bin/patool \
       --prefix PATH : ${lib.makeBinPath [
-        archiver
         arj
         bintools
         bzip2

--- a/modules/home-manager/programs/patool/package.nix
+++ b/modules/home-manager/programs/patool/package.nix
@@ -11,6 +11,7 @@
 
   # Various archive formats supported by patool.
   # TODO: arc, unace, unadf, unalz, xdms, shorten, zoo
+  _7zz,
   arj,
   bintools,
   bzip2,
@@ -29,7 +30,6 @@
   lzop,
   monkeysAudio,
   ncompress,
-  p7zip,
   rar,
   rzip,
   sharutils,
@@ -59,6 +59,7 @@ in symlinkJoin {
       --prefix PATH : ${lib.makeBinPath [
         file
 
+        _7zz
         arj
         bintools
         bzip2
@@ -77,7 +78,6 @@ in symlinkJoin {
         lzop
         monkeysAudio
         ncompress
-        p7zip
         rar
         rzip'
         sharutils

--- a/modules/home-manager/programs/patool/package.nix
+++ b/modules/home-manager/programs/patool/package.nix
@@ -6,6 +6,10 @@
 
   patool,
 
+  # To help disambiguate different archives
+  file,
+
+  # Various archive formats supported by patool.
   # TODO: arc, unace, unadf, unalz, xdms, shorten, zoo
   arj,
   bintools,
@@ -53,6 +57,8 @@ in symlinkJoin {
   postBuild = ''
     wrapProgram $out/bin/patool \
       --prefix PATH : ${lib.makeBinPath [
+        file
+
         arj
         bintools
         bzip2

--- a/modules/nixos/programs/nix/module.nix
+++ b/modules/nixos/programs/nix/module.nix
@@ -28,9 +28,9 @@ in {
       # Use github:viperML/nh as our "nix wrapper" program.
       programs.nh.enable = true;
 
-      # Wrap the official nix binary with a snippet to allow
+      # Wrap a compatible nix binary with a snippet to allow
       # rapid repl access to `pkgs.*` and `lib.*` attributes.
-      nix.package = pkgs.callPackage ./package.nix { nix = pkgs.nixVersions.git; };
+      nix.package = pkgs.callPackage ./package.nix { nix = pkgs.lix; };
     }
     {
       # Throttle the nix-daemon so it doesn't consume
@@ -110,7 +110,7 @@ in {
 
           # Improve the chances of the store surviving a random crash.
           fsync-metadata = true;
-          fsync-store-paths = true;
+          # fsync-store-paths = true; TODO: bring back when Lix 2.92
 
           http-connections = 0; # unlimited connections!!
 
@@ -166,7 +166,7 @@ in {
             # Some interesting features.
             # "fetch-closures"
             "no-url-literals"
-            "pipe-operators"
+            "pipe-operator"
           ];
         }
       ];

--- a/modules/nixos/programs/powertop/config.nix
+++ b/modules/nixos/programs/powertop/config.nix
@@ -1,0 +1,15 @@
+{
+  config,
+  lib,
+  pkgs,
+  ...
+}:
+let
+  cfg = config.my.programs.powertop;
+in {
+  config = lib.mkIf cfg.enable {
+    my.persist.directories = [ "/var/cache/powertop" ];
+
+    environment.systemPackages = [ pkgs.powertop ];
+  };
+}

--- a/modules/nixos/programs/powertop/module.nix
+++ b/modules/nixos/programs/powertop/module.nix
@@ -1,0 +1,9 @@
+{
+  ...
+}:
+{
+  imports = [
+    ./options.nix
+    ./config.nix
+  ];
+}

--- a/modules/nixos/programs/powertop/options.nix
+++ b/modules/nixos/programs/powertop/options.nix
@@ -1,0 +1,11 @@
+{
+  lib,
+  ...
+}:
+{
+  options = {
+    my.programs.powertop = {
+      enable = lib.mkDefaultEnableOption "powertop";
+    };
+  };
+}

--- a/users/frontear/home/default.nix
+++ b/users/frontear/home/default.nix
@@ -60,7 +60,7 @@
       enable = true;
 
       config = {
-        user.email = "perm-iterate-0b@icloud.com";
+        user.email = "contact@frontear.dev";
         user.name = "Ali Rizvi";
         user.signingKey = "4BC247743ACFF25E";
 

--- a/users/frontear/home/neovim/default.nix
+++ b/users/frontear/home/neovim/default.nix
@@ -94,18 +94,18 @@
             }),
           })
 
-          local lsp_format = require("lsp-format")
+          --local lsp_format = require("lsp-format")
 
-          lsp_format.setup {}
+          --lsp_format.setup {}
 
           local lspconfig = require("lspconfig")
           local capabilities = require("cmp_nvim_lsp").default_capabilities()
-          local on_attach = lsp_format.on_attach
+          --local on_attach = lsp_format.on_attach
 
           ${lib.concatStringsSep "\n" (map (lsp: ''
             lspconfig.${lsp}.setup({
               capabilities = capabilities,
-              on_attach = on_attach
+              --on_attach = on_attach
             })
           '') [
             "basedpyright"

--- a/users/frontear/home/neovim/default.nix
+++ b/users/frontear/home/neovim/default.nix
@@ -12,29 +12,31 @@
     ];
 
     init = ''
-      vim.opt.cursorline = true
-
-      vim.opt.fileencoding = "utf-8"
-      vim.opt.fileformat = "unix"
+      vim.g.mapleader = ' '
+      vim.g.localmapleader = ' '
 
       vim.opt.tabstop = 2
       vim.opt.softtabstop = 2
       vim.opt.shiftwidth = 2
       vim.opt.expandtab = true
 
-      vim.opt.fixeol = true
-      vim.opt.eol = true
-
-      vim.opt.textwidth = 80
-      vim.opt.spelllang = "en_us"
-
-      vim.opt.scrolloff = 5
-
-      vim.opt.wrap = true
-      vim.opt.undofile = true
-
+      vim.opt.cursorline = true
       vim.opt.number = true
       vim.cmd("highlight LineNr ctermfg=grey")
+
+      vim.opt.scrolloff = 5
+      vim.opt.textwidth = 80
+      vim.opt.wrap = true
+
+      vim.opt.undofile = true
+
+      vim.opt.splitright = true
+      vim.opt.splitbelow = true
+
+      vim.keymap.set('n', "<C-Left>", "<cmd>wincmd h<CR>")
+      vim.keymap.set('n', "<C-Right>", "<cmd>wincmd l<CR>")
+      vim.keymap.set('n', "<C-Up>", "<cmd>wincmd k<CR>")
+      vim.keymap.set('n', "<C-Down>", "<cmd>wincmd j<CR>")
     '';
 
     plugins = [


### PR DESCRIPTION
Hello again after 2 months (more or less). Things have been very slow on the updates here because I haven't really had much time to tinker and play around with things. Instead, I've just been churning projects and work for school, which has left very little "mess with dotfiles" time. I expect this slow period to continue for a bit longer until the term is over, though it might continue depending on circumstances. Nonetheless, I'm quite happy with my dotfiles as they are, even if they aren't as fancy as everyone elses, or as complete, they serve my machine and ultimately that's all I really need.

## Things Done
1. (cd761111421de15967a1e2548f41aa9495f04ae1) Change my default git email to `contact@frontear.dev`, as the first mark in my transition to a more professional image of myself
2. (9767767207f961e21e9c293b5474d72a9f127bd4) Install the `libimobiledevice` tool suite by default, as they're quite useful for me given my various iOS devices
3. (1721970cda47a6c55e87a8549a5d256bb29e272a) Update `flake.lock` and removed a vulnerable and outdated software from the `patool` derivation, since it serves no practical purpose for me (and is unsafe of course)
4. (549db036e7e99bc3ad2399c89547e0e0c5b4b224) Add the `file` executable to `patool`'s PATH by default, since it uses it to determine what type a file is via magic numbers in the header
5. (ba92eef9a5d6a13bb861ebc111020d876dd07495) Switch from `p7zip` to `_7zz`, the official binary from https://7-zip.org, for greater reliability in `patool`
6. (cf0e50909726b73a959e057460637bc6036f8223) Override `isoImage.isoBaseName` so that iso artifacts have a better naming
7. (1d8382bd0a9bc03e328af30267049ab4fc108561) Update `flake.lock`
8. (0164bebd529f2e3b07c317d5e6bf37bd98ac0c82) Disable `lsp_format` in neovim, as its extremely opinionated and goes against my personal preference for a style. In the future I do think having a consistent style enforcer is useful, but as it stands I was fighting the formatter more than doing any real coding
9. (32143882fc2ddc8dbfbc4f6e6730b2e59cb9a971) Introduce a powertop module for watching and monitoring power statistics. This was introduced because I wanted to measure my battery's watt-hour ratings and see why it sucks so much
10. (12d8c7e5947b6e4577e976b98764da877bfa714e) Add some nice new keybinds and settings for neovim, and remove some useless ones. Most of the new ones in particular came from https://github.com/nvim-lua/kickstart.nvim, very awesome project. Eventually I want to follow along with this and develop my config in a structure that makes more sense than what I have right now
11. (b74794f6cbea35523d0c54d19cc47955146a4594) Switch back to using Lix, primarily due to a copying bug/regression that's had no real resolution for the better part of a year on the Nix side
12. (369f778fc791306c8c15df641861cfec27ed6f20) Update `flake.lock` again