### PR TITLE
staging: 2025-06-05

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -25,11 +25,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1746413188,
-        "narHash": "sha256-i6BoiQP0PasExESQHszC0reQHfO6D4aI2GzOwZMOI20=",
+        "lastModified": 1746912617,
+        "narHash": "sha256-SSw/98B3Htw7iJWCyq08fAEL5w+a/Vj+YbQq0msVFTA=",
         "owner": "nix-community",
         "repo": "home-manager",
-        "rev": "8a318641ac13d3bc0a53651feaee9560f9b2d89a",
+        "rev": "9ef92f1c6b77944198fd368ec805ced842352a1d",
         "type": "github"
       },
       "original": {
@@ -40,11 +40,11 @@
     },
     "nixos-hardware": {
       "locked": {
-        "lastModified": 1746468201,
-        "narHash": "sha256-hSOSlrvMJwGr8hX/gc0mnhUf5UIClMDUAadfXlSXzfc=",
+        "lastModified": 1746814339,
+        "narHash": "sha256-hf2lICJzwACWuzHCmZn5NI6LUAOgGdR1yh8ip+duyhk=",
         "owner": "NixOS",
         "repo": "nixos-hardware",
-        "rev": "6aabf68429c0a414221d1790945babfb6a0bd068",
+        "rev": "3c5e12673265dfb0de3d9121420c0c2153bf21e0",
         "type": "github"
       },
       "original": {
@@ -55,11 +55,11 @@
     },
     "nixpkgs": {
       "locked": {
-        "lastModified": 1746328495,
-        "narHash": "sha256-uKCfuDs7ZM3QpCE/jnfubTg459CnKnJG/LwqEVEdEiw=",
+        "lastModified": 1746663147,
+        "narHash": "sha256-Ua0drDHawlzNqJnclTJGf87dBmaO/tn7iZ+TCkTRpRc=",
         "owner": "NixOS",
         "repo": "nixpkgs",
-        "rev": "979daf34c8cacebcd917d540070b52a3c2b9b16e",
+        "rev": "dda3dcd3fe03e991015e9a74b22d35950f264a54",
         "type": "github"
       },
       "original": {

--- a/flake.lock
+++ b/flake.lock
@@ -5,11 +5,11 @@
         "nixpkgs-lib": "nixpkgs-lib"
       },
       "locked": {
-        "lastModified": 1741352980,
-        "narHash": "sha256-+u2UunDA4Cl5Fci3m7S643HzKmIDAe+fiXrLqYsR2fs=",
+        "lastModified": 1743550720,
+        "narHash": "sha256-hIshGgKZCgWh6AYJpJmRgFdR3WUbkY04o82X05xqQiY=",
         "owner": "hercules-ci",
         "repo": "flake-parts",
-        "rev": "f4330d22f1c5d2ba72d3d22df5597d123fdb60a9",
+        "rev": "c621e8422220273271f52058f618c94e405bb0f5",
         "type": "github"
       },
       "original": {
@@ -25,11 +25,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1742588233,
-        "narHash": "sha256-Fi5g8H5FXMSRqy+mU6gPG0v+C9pzjYbkkiePtz8+PpA=",
+        "lastModified": 1743869639,
+        "narHash": "sha256-Xhe3whfRW/Ay05z9m1EZ1/AkbV1yo0tm1CbgjtCi4rQ=",
         "owner": "nix-community",
         "repo": "home-manager",
-        "rev": "296ddc64627f4a6a4eb447852d7346b9dd16197d",
+        "rev": "d094c6763c6ddb860580e7d3b4201f8f496a6836",
         "type": "github"
       },
       "original": {
@@ -40,11 +40,11 @@
     },
     "nixos-hardware": {
       "locked": {
-        "lastModified": 1742376361,
-        "narHash": "sha256-VFMgJkp/COvkt5dnkZB4D2szVdmF6DGm5ZdVvTUy61c=",
+        "lastModified": 1743420942,
+        "narHash": "sha256-b/exDDQSLmENZZgbAEI3qi9yHkuXAXCPbormD8CSJXo=",
         "owner": "NixOS",
         "repo": "nixos-hardware",
-        "rev": "daaae13dff0ecc692509a1332ff9003d9952d7a9",
+        "rev": "de6fc5551121c59c01e2a3d45b277a6d05077bc4",
         "type": "github"
       },
       "original": {
@@ -55,11 +55,11 @@
     },
     "nixpkgs": {
       "locked": {
-        "lastModified": 1742422364,
-        "narHash": "sha256-mNqIplmEohk5jRkqYqG19GA8MbQ/D4gQSK0Mu4LvfRQ=",
+        "lastModified": 1743583204,
+        "narHash": "sha256-F7n4+KOIfWrwoQjXrL2wD9RhFYLs2/GGe/MQY1sSdlE=",
         "owner": "NixOS",
         "repo": "nixpkgs",
-        "rev": "a84ebe20c6bc2ecbcfb000a50776219f48d134cc",
+        "rev": "2c8d3f48d33929642c1c12cd243df4cc7d2ce434",
         "type": "github"
       },
       "original": {
@@ -71,11 +71,11 @@
     },
     "nixpkgs-lib": {
       "locked": {
-        "lastModified": 1740877520,
-        "narHash": "sha256-oiwv/ZK/2FhGxrCkQkB83i7GnWXPPLzoqFHpDD3uYpk=",
+        "lastModified": 1743296961,
+        "narHash": "sha256-b1EdN3cULCqtorQ4QeWgLMrd5ZGOjLSLemfa00heasc=",
         "owner": "nix-community",
         "repo": "nixpkgs.lib",
-        "rev": "147dee35aab2193b174e4c0868bd80ead5ce755c",
+        "rev": "e4822aea2a6d1cdd36653c134cacfd64c97ff4fa",
         "type": "github"
       },
       "original": {

--- a/flake.lock
+++ b/flake.lock
@@ -5,11 +5,11 @@
         "nixpkgs-lib": "nixpkgs-lib"
       },
       "locked": {
-        "lastModified": 1743550720,
-        "narHash": "sha256-hIshGgKZCgWh6AYJpJmRgFdR3WUbkY04o82X05xqQiY=",
+        "lastModified": 1748821116,
+        "narHash": "sha256-F82+gS044J1APL0n4hH50GYdPRv/5JWm34oCJYmVKdE=",
         "owner": "hercules-ci",
         "repo": "flake-parts",
-        "rev": "c621e8422220273271f52058f618c94e405bb0f5",
+        "rev": "49f0870db23e8c1ca0b5259734a02cd9e1e371a1",
         "type": "github"
       },
       "original": {
@@ -25,11 +25,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1748182899,
-        "narHash": "sha256-r6MHSalDFydlUmjorVTSsyhLjIt8VWNtGc5+mffXvFQ=",
+        "lastModified": 1748955489,
+        "narHash": "sha256-OmZXyW2g5qIuo5Te74McwR0TwauCO2sF3/SjGDVuxyg=",
         "owner": "nix-community",
         "repo": "home-manager",
-        "rev": "901f8fef7f349cf8a8e97b3230b22fd592df9160",
+        "rev": "bb846c031be68a96466b683be32704ef6e07b159",
         "type": "github"
       },
       "original": {
@@ -40,11 +40,11 @@
     },
     "nixos-hardware": {
       "locked": {
-        "lastModified": 1747900541,
-        "narHash": "sha256-dn64Pg9xLETjblwZs9Euu/SsjW80pd6lr5qSiyLY1pg=",
+        "lastModified": 1748942041,
+        "narHash": "sha256-HEu2gTct7nY0tAPRgBtqYepallryBKR1U8B4v2zEEqA=",
         "owner": "NixOS",
         "repo": "nixos-hardware",
-        "rev": "11f2d9ea49c3e964315215d6baa73a8d42672f06",
+        "rev": "fc7c4714125cfaa19b048e8aaf86b9c53e04d853",
         "type": "github"
       },
       "original": {
@@ -55,11 +55,11 @@
     },
     "nixpkgs": {
       "locked": {
-        "lastModified": 1748026106,
-        "narHash": "sha256-6m1Y3/4pVw1RWTsrkAK2VMYSzG4MMIj7sqUy7o8th1o=",
+        "lastModified": 1748693115,
+        "narHash": "sha256-StSrWhklmDuXT93yc3GrTlb0cKSS0agTAxMGjLKAsY8=",
         "owner": "NixOS",
         "repo": "nixpkgs",
-        "rev": "063f43f2dbdef86376cc29ad646c45c46e93234c",
+        "rev": "910796cabe436259a29a72e8d3f5e180fc6dfacc",
         "type": "github"
       },
       "original": {
@@ -71,11 +71,11 @@
     },
     "nixpkgs-lib": {
       "locked": {
-        "lastModified": 1743296961,
-        "narHash": "sha256-b1EdN3cULCqtorQ4QeWgLMrd5ZGOjLSLemfa00heasc=",
+        "lastModified": 1748740939,
+        "narHash": "sha256-rQaysilft1aVMwF14xIdGS3sj1yHlI6oKQNBRTF40cc=",
         "owner": "nix-community",
         "repo": "nixpkgs.lib",
-        "rev": "e4822aea2a6d1cdd36653c134cacfd64c97ff4fa",
+        "rev": "656a64127e9d791a334452c6b6606d17539476e2",
         "type": "github"
       },
       "original": {

--- a/flake.lock
+++ b/flake.lock
@@ -25,11 +25,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1746912617,
-        "narHash": "sha256-SSw/98B3Htw7iJWCyq08fAEL5w+a/Vj+YbQq0msVFTA=",
+        "lastModified": 1748182899,
+        "narHash": "sha256-r6MHSalDFydlUmjorVTSsyhLjIt8VWNtGc5+mffXvFQ=",
         "owner": "nix-community",
         "repo": "home-manager",
-        "rev": "9ef92f1c6b77944198fd368ec805ced842352a1d",
+        "rev": "901f8fef7f349cf8a8e97b3230b22fd592df9160",
         "type": "github"
       },
       "original": {
@@ -40,11 +40,11 @@
     },
     "nixos-hardware": {
       "locked": {
-        "lastModified": 1746814339,
-        "narHash": "sha256-hf2lICJzwACWuzHCmZn5NI6LUAOgGdR1yh8ip+duyhk=",
+        "lastModified": 1747900541,
+        "narHash": "sha256-dn64Pg9xLETjblwZs9Euu/SsjW80pd6lr5qSiyLY1pg=",
         "owner": "NixOS",
         "repo": "nixos-hardware",
-        "rev": "3c5e12673265dfb0de3d9121420c0c2153bf21e0",
+        "rev": "11f2d9ea49c3e964315215d6baa73a8d42672f06",
         "type": "github"
       },
       "original": {
@@ -55,11 +55,11 @@
     },
     "nixpkgs": {
       "locked": {
-        "lastModified": 1746663147,
-        "narHash": "sha256-Ua0drDHawlzNqJnclTJGf87dBmaO/tn7iZ+TCkTRpRc=",
+        "lastModified": 1748026106,
+        "narHash": "sha256-6m1Y3/4pVw1RWTsrkAK2VMYSzG4MMIj7sqUy7o8th1o=",
         "owner": "NixOS",
         "repo": "nixpkgs",
-        "rev": "dda3dcd3fe03e991015e9a74b22d35950f264a54",
+        "rev": "063f43f2dbdef86376cc29ad646c45c46e93234c",
         "type": "github"
       },
       "original": {

--- a/flake.lock
+++ b/flake.lock
@@ -25,11 +25,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1743869639,
-        "narHash": "sha256-Xhe3whfRW/Ay05z9m1EZ1/AkbV1yo0tm1CbgjtCi4rQ=",
+        "lastModified": 1746413188,
+        "narHash": "sha256-i6BoiQP0PasExESQHszC0reQHfO6D4aI2GzOwZMOI20=",
         "owner": "nix-community",
         "repo": "home-manager",
-        "rev": "d094c6763c6ddb860580e7d3b4201f8f496a6836",
+        "rev": "8a318641ac13d3bc0a53651feaee9560f9b2d89a",
         "type": "github"
       },
       "original": {
@@ -40,11 +40,11 @@
     },
     "nixos-hardware": {
       "locked": {
-        "lastModified": 1743420942,
-        "narHash": "sha256-b/exDDQSLmENZZgbAEI3qi9yHkuXAXCPbormD8CSJXo=",
+        "lastModified": 1746468201,
+        "narHash": "sha256-hSOSlrvMJwGr8hX/gc0mnhUf5UIClMDUAadfXlSXzfc=",
         "owner": "NixOS",
         "repo": "nixos-hardware",
-        "rev": "de6fc5551121c59c01e2a3d45b277a6d05077bc4",
+        "rev": "6aabf68429c0a414221d1790945babfb6a0bd068",
         "type": "github"
       },
       "original": {
@@ -55,11 +55,11 @@
     },
     "nixpkgs": {
       "locked": {
-        "lastModified": 1743583204,
-        "narHash": "sha256-F7n4+KOIfWrwoQjXrL2wD9RhFYLs2/GGe/MQY1sSdlE=",
+        "lastModified": 1746328495,
+        "narHash": "sha256-uKCfuDs7ZM3QpCE/jnfubTg459CnKnJG/LwqEVEdEiw=",
         "owner": "NixOS",
         "repo": "nixpkgs",
-        "rev": "2c8d3f48d33929642c1c12cd243df4cc7d2ce434",
+        "rev": "979daf34c8cacebcd917d540070b52a3c2b9b16e",
         "type": "github"
       },
       "original": {

--- a/lib/default.nix
+++ b/lib/default.nix
@@ -61,6 +61,6 @@
 
   types = rec {
     systemPath = prev.types.path;
-    userPath = prev.types.either systemPath (prev.types.strMatching "~/.+");
+    userPath = prev.types.either systemPath (prev.types.strMatching "~/[^~]+");
   } // prev.types;
 }

--- a/modules/home-manager/programs/gnupg/module.nix
+++ b/modules/home-manager/programs/gnupg/module.nix
@@ -73,7 +73,7 @@ in {
       enable = cfg.agent.enable;
       enableSshSupport = cfg.agent.enableSSHSupport;
 
-      pinentryPackage = cfg.agent.pinentryPackage;
+      pinentry.package = cfg.agent.pinentryPackage;
 
       sshKeys = cfg.agent.sshKeys;
     };

--- a/modules/home-manager/programs/microsoft-edge/package.nix
+++ b/modules/home-manager/programs/microsoft-edge/package.nix
@@ -1,8 +1,294 @@
+# Pulled from https://github.com/NixOS/nixpkgs/pull/407617/files
 {
-  microsoft-edge,
+  fetchurl,
+  lib,
+  makeWrapper,
+  patchelf,
+  stdenv,
 
-  commandLineArgs ? ""
+  # Linked dynamic libraries.
+  alsa-lib,
+  at-spi2-atk,
+  at-spi2-core,
+  atk,
+  cairo,
+  cups,
+  dbus,
+  expat,
+  fontconfig,
+  freetype,
+  gcc-unwrapped,
+  gdk-pixbuf,
+  glib,
+  gtk3,
+  gtk4,
+  libdrm,
+  libglvnd,
+  libkrb5,
+  libX11,
+  libxcb,
+  libXcomposite,
+  libXcursor,
+  libXdamage,
+  libXext,
+  libXfixes,
+  libXi,
+  libxkbcommon,
+  libXrandr,
+  libXrender,
+  libXScrnSaver,
+  libxshmfence,
+  libXtst,
+  libgbm,
+  nspr,
+  nss,
+  pango,
+  pipewire,
+  vulkan-loader,
+  wayland, # ozone/wayland
+
+  # Command line programs
+  coreutils,
+
+  # command line arguments which are always set e.g "--disable-gpu"
+  commandLineArgs ? "",
+
+  # Will crash without.
+  systemd,
+
+  # Loaded at runtime.
+  libexif,
+  pciutils,
+
+  # Additional dependencies according to other distros.
+  ## Ubuntu
+  curl,
+  liberation_ttf,
+  util-linux,
+  wget,
+  xdg-utils,
+  ## Arch Linux.
+  flac,
+  harfbuzz,
+  icu,
+  libopus,
+  libpng,
+  snappy,
+  speechd-minimal,
+  ## Gentoo
+  bzip2,
+  libcap,
+
+  # Necessary for USB audio devices.
+  libpulseaudio,
+  pulseSupport ? true,
+
+  adwaita-icon-theme,
+  gsettings-desktop-schemas,
+
+  # For video acceleration via VA-API (--enable-features=VaapiVideoDecoder)
+  libva,
+  libvaSupport ? true,
+
+  # For Vulkan support (--enable-features=Vulkan)
+  addDriverRunpath,
+
+  # Edge AAD sync
+  cacert,
+  libsecret,
+
+  # Edge Specific
+  libuuid,
 }:
-microsoft-edge.override {
-  inherit commandLineArgs;
-}
+
+let
+
+  opusWithCustomModes = libopus.override { withCustomModes = true; };
+
+  deps =
+    [
+      alsa-lib
+      at-spi2-atk
+      at-spi2-core
+      atk
+      bzip2
+      cacert
+      cairo
+      coreutils
+      cups
+      curl
+      dbus
+      expat
+      flac
+      fontconfig
+      freetype
+      gcc-unwrapped.lib
+      gdk-pixbuf
+      glib
+      harfbuzz
+      icu
+      libcap
+      libdrm
+      liberation_ttf
+      libexif
+      libglvnd
+      libkrb5
+      libpng
+      libX11
+      libxcb
+      libXcomposite
+      libXcursor
+      libXdamage
+      libXext
+      libXfixes
+      libXi
+      libxkbcommon
+      libXrandr
+      libXrender
+      libXScrnSaver
+      libxshmfence
+      libXtst
+      libgbm
+      nspr
+      nss
+      opusWithCustomModes
+      pango
+      pciutils
+      pipewire
+      snappy
+      speechd-minimal
+      systemd
+      util-linux
+      vulkan-loader
+      wayland
+      wget
+      libsecret
+      libuuid
+    ]
+    ++ lib.optional pulseSupport libpulseaudio
+    ++ lib.optional libvaSupport libva
+    ++ [
+      gtk3
+      gtk4
+    ];
+in
+
+stdenv.mkDerivation (finalAttrs: {
+  pname = "microsoft-edge";
+  version = "136.0.3240.92";
+
+  src = fetchurl {
+    url = "https://packages.microsoft.com/repos/edge/pool/main/m/microsoft-edge-stable/microsoft-edge-stable_${finalAttrs.version}-1_amd64.deb";
+    hash = "sha256-BLQofnS+VZw2Xza+s4+oIz3iTtjIoX2V2c6DVHlR2MM=";
+  };
+
+  # With strictDeps on, some shebangs were not being patched correctly
+  # ie, $out/share/microsoft/msedge/microsoft-edge
+  strictDeps = false;
+
+  nativeBuildInputs = [
+    makeWrapper
+    patchelf
+  ];
+
+  buildInputs = [
+    # needed for XDG_ICON_DIRS
+    adwaita-icon-theme
+    glib
+    gtk3
+    gtk4
+    # needed for GSETTINGS_SCHEMAS_PATH
+    gsettings-desktop-schemas
+  ];
+
+  unpackPhase = ''
+    runHook preUnpack
+    ar x $src
+    tar xf data.tar.xz
+    runHook postUnpack
+  '';
+
+  rpath = lib.makeLibraryPath deps + ":" + lib.makeSearchPathOutput "lib" "lib64" deps;
+  binpath = lib.makeBinPath deps;
+
+  installPhase = ''
+    runHook preInstall
+
+    appname=msedge
+    dist=stable
+
+    exe=$out/bin/microsoft-edge
+
+    mkdir -p $out/bin $out/share
+    cp -v -a opt/* $out/share
+    cp -v -a usr/share/* $out/share
+
+    # replace bundled vulkan-loader
+    rm -v $out/share/microsoft/$appname/libvulkan.so.1
+    ln -v -s -t "$out/share/microsoft/$appname" "${lib.getLib vulkan-loader}/lib/libvulkan.so.1"
+
+    substituteInPlace $out/share/microsoft/$appname/microsoft-edge \
+      --replace-fail 'CHROME_WRAPPER' 'WRAPPER'
+    substituteInPlace $out/share/applications/microsoft-edge.desktop \
+      --replace-fail /usr/bin/microsoft-edge-$dist $exe
+    substituteInPlace $out/share/gnome-control-center/default-apps/microsoft-edge.xml \
+      --replace-fail /opt/microsoft/msedge $exe
+    substituteInPlace $out/share/menu/microsoft-edge.menu \
+      --replace-fail /opt $out/share \
+      --replace-fail $out/share/microsoft/$appname/microsoft-edge $exe
+
+    for icon_file in $out/share/microsoft/msedge/product_logo_[0-9]*.png; do
+      num_and_suffix="''${icon_file##*logo_}"
+      if [ $dist = "stable" ]; then
+        icon_size="''${num_and_suffix%.*}"
+      else
+        icon_size="''${num_and_suffix%_*}"
+      fi
+      logo_output_prefix="$out/share/icons/hicolor"
+      logo_output_path="$logo_output_prefix/''${icon_size}x''${icon_size}/apps"
+      mkdir -p "$logo_output_path"
+      mv "$icon_file" "$logo_output_path/microsoft-edge.png"
+    done
+
+    # "--simulate-outdated-no-au" disables auto updates and browser outdated popup
+    makeWrapper "$out/share/microsoft/$appname/microsoft-edge" "$exe" \
+      --prefix LD_LIBRARY_PATH : "$rpath" \
+      --prefix PATH            : "$binpath" \
+      --suffix PATH            : "${lib.makeBinPath [ xdg-utils ]}" \
+      --prefix XDG_DATA_DIRS   : "$XDG_ICON_DIRS:$GSETTINGS_SCHEMAS_PATH:${addDriverRunpath.driverLink}/share" \
+      --set SSL_CERT_FILE "${cacert}/etc/ssl/certs/ca-bundle.crt" \
+      --set CHROME_WRAPPER  "microsoft-edge-$dist" \
+      --add-flags "\''${NIXOS_OZONE_WL:+\''${WAYLAND_DISPLAY:+--ozone-platform-hint=auto --enable-features=WaylandWindowDecorations --enable-wayland-ime=true}}" \
+      --add-flags "--simulate-outdated-no-au='Tue, 31 Dec 2099 23:59:59 GMT'" \
+      --add-flags ${lib.escapeShellArg commandLineArgs}
+
+    # Make sure that libGL and libvulkan are found by ANGLE libGLESv2.so
+    patchelf --set-rpath $rpath $out/share/microsoft/$appname/lib*GL*
+
+    # Edge specific set liboneauth
+    patchelf --set-rpath $rpath $out/share/microsoft/$appname/liboneauth.so
+
+    for elf in $out/share/microsoft/$appname/{msedge,msedge-sandbox,msedge_crashpad_handler}; do
+      patchelf --set-rpath $rpath $elf
+      patchelf --set-interpreter "$(cat $NIX_CC/nix-support/dynamic-linker)" $elf
+    done
+
+    runHook postInstall
+  '';
+
+  passthru.updateScript = ./update.py;
+
+  meta = {
+    changelog = "https://learn.microsoft.com/en-us/deployedge/microsoft-edge-relnote-stable-channel";
+    description = "Web browser from Microsoft";
+    homepage = "https://www.microsoft.com/en-us/edge";
+    license = lib.licenses.unfree;
+    mainProgram = "microsoft-edge";
+    maintainers = with lib.maintainers; [
+      kuwii
+      rhysmdnz
+    ];
+    platforms = [ "x86_64-linux" ];
+    sourceProvenance = with lib.sourceTypes; [ binaryNativeCode ];
+  };
+})

--- a/modules/home-manager/programs/zsh/module.nix
+++ b/modules/home-manager/programs/zsh/module.nix
@@ -127,7 +127,7 @@ in {
       })
       ({
         # Setup prompt
-        initExtra = cfg.promptInit;
+        initContent = cfg.promptInit;
       })
       ({
         # Need to strip home from dotDir, because hm decided to append '$HOME' here

--- a/modules/nixos/programs/nix/module.nix
+++ b/modules/nixos/programs/nix/module.nix
@@ -162,6 +162,7 @@ in {
             # Critical flags for flakes.
             "flakes"
             "nix-command"
+            "repl-flake"
             
             # Some interesting features.
             # "fetch-closures"

--- a/nix/templates/parts/.gitignore
+++ b/nix/templates/parts/.gitignore
@@ -1,0 +1,4 @@
+.direnv/
+.envrc
+
+result


### PR DESCRIPTION
Hello again. I have not really had the time nor motivation to excessively tinker with my system, nor really make much use of it, so progress has been quite stale in development here. Most of the PRs were simple updates and occasional changes. The most note-worthy change here would be in the persist module, which helps makes a small bit of progress towards #33 (soon..)

## Things Done
1. (1e5327c1e192bf7ae320cad92292ae5ee30c9da3) Add a default `.gitignore` file to my flake-parts template, which minimally ignores the `direnv` folders as well as the `nix` result symlink.
2. (45cfa2fe9da1846bc4724729687e245857e77401) Update `flake.lock`
3. (88147585f250dc4d5f65e5fcf97765a65efeffe2) Update `flake.lock`
4. (3bdba78d5b49cb38379f2a4741e56a6e24894bb0) Introduce a `src` and `dst` attribute for the toplevel persist entries which allows individual entries to control their destination and source locations. Furthermore, improve the `lib.userPath` pattern match to disallow `~` characters after the first `~/`, which prevents some unlikely but possible errors
5. (75f64c79cb0e9837628fe985d9f30c88a97a65f1) Change attribute names as per deprecation warnings from home-manager's pinentry and zsh modules
6. (98a706bcb7e0fe855ae83e7e9c9d1d6b31179138) Update `flake.lock`
7. (30a6a6774c1e3c713dd8543036d65c8240937881) Update `flake.lock` and copy the now-deleted upstream derivation for microsoft-edge, until it hopefully returns.
8. (5cd4dfac0a1d640d4642f35c1904e6058f3e061d) Update `flake.lock` and add `repl-flake` to experimental features of Nix