### PR TITLE
2026-01-23 -> 2026-02-20

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -1,28 +1,5 @@
 {
   "nodes": {
-    "DankMaterialShell": {
-      "inputs": {
-        "nixpkgs": [
-          "nixpkgs"
-        ],
-        "quickshell": [
-          "quickshell"
-        ]
-      },
-      "locked": {
-        "lastModified": 1767917815,
-        "narHash": "sha256-e8JnpcAR5vgaDbum92TchDysxbWgF/BfzMrAiuH5Qj8=",
-        "owner": "AvengeMedia",
-        "repo": "DankMaterialShell",
-        "rev": "5ae2cd1dfb7145f10482567f8a66f5607fc606a7",
-        "type": "github"
-      },
-      "original": {
-        "owner": "AvengeMedia",
-        "repo": "DankMaterialShell",
-        "type": "github"
-      }
-    },
     "base16": {
       "inputs": {
         "fromYaml": "fromYaml"
@@ -158,11 +135,11 @@
         "nixpkgs-lib": "nixpkgs-lib"
       },
       "locked": {
-        "lastModified": 1767609335,
-        "narHash": "sha256-feveD98mQpptwrAEggBQKJTYbvwwglSbOv53uCfH9PY=",
+        "lastModified": 1768135262,
+        "narHash": "sha256-PVvu7OqHBGWN16zSi6tEmPwwHQ4rLPU9Plvs8/1TUBY=",
         "owner": "hercules-ci",
         "repo": "flake-parts",
-        "rev": "250481aafeb741edfe23d29195671c19b36b6dca",
+        "rev": "80daad04eddbbf5a4d883996a73f3f542fa437ac",
         "type": "github"
       },
       "original": {
@@ -234,11 +211,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1767909183,
-        "narHash": "sha256-u/bcU0xePi5bgNoRsiqSIwaGBwDilKKFTz3g0hqOBAo=",
+        "lastModified": 1769187349,
+        "narHash": "sha256-clG+nT6I2qxjIgk5WoSDKJyNhzKJs9jzbCujPF2S/yg=",
         "owner": "nix-community",
         "repo": "home-manager",
-        "rev": "cd6e96d56ed4b2a779ac73a1227e0bb1519b3509",
+        "rev": "082a4cd87c6089d1d9c58ebe52655f9e07245fcb",
         "type": "github"
       },
       "original": {
@@ -289,11 +266,11 @@
         "treefmt-nix": "treefmt-nix"
       },
       "locked": {
-        "lastModified": 1767843622,
-        "narHash": "sha256-0307NMFhgAn9H1SU5Bn6MIee1I87VVlqbIE04vT7OuY=",
+        "lastModified": 1768967124,
+        "narHash": "sha256-kUCZiVuxw+XEKET8xzm5Wi4Y2JAOr4bQ4+p6ARISoIo=",
         "owner": "nix-community",
         "repo": "nixos-facter",
-        "rev": "d6f42d5fb2b136f3bbdc4fed346ca5fc19567939",
+        "rev": "c0a9fb6744a76c44a29344699a2a2e73adf59d00",
         "type": "github"
       },
       "original": {
@@ -319,11 +296,11 @@
     },
     "nixpkgs": {
       "locked": {
-        "lastModified": 1767767207,
-        "narHash": "sha256-Mj3d3PfwltLmukFal5i3fFt27L6NiKXdBezC1EBuZs4=",
+        "lastModified": 1769018530,
+        "narHash": "sha256-MJ27Cy2NtBEV5tsK+YraYr2g851f3Fl1LpNHDzDX15c=",
         "owner": "NixOS",
         "repo": "nixpkgs",
-        "rev": "5912c1772a44e31bf1c63c0390b90501e5026886",
+        "rev": "88d3861acdd3d2f0e361767018218e51810df8a1",
         "type": "github"
       },
       "original": {
@@ -373,35 +350,13 @@
         "type": "github"
       }
     },
-    "quickshell": {
-      "inputs": {
-        "nixpkgs": [
-          "nixpkgs"
-        ]
-      },
-      "locked": {
-        "lastModified": 1767874269,
-        "narHash": "sha256-++tlVUxW8nq0uqbcU1h7X0QQnOehY3/EWUCOr1kbVvM=",
-        "owner": "quickshell-mirror",
-        "repo": "quickshell",
-        "rev": "5d8354a88be2ce2c16add7457c94e29f6e7c3684",
-        "type": "github"
-      },
-      "original": {
-        "owner": "quickshell-mirror",
-        "repo": "quickshell",
-        "type": "github"
-      }
-    },
     "root": {
       "inputs": {
-        "DankMaterialShell": "DankMaterialShell",
         "flake-parts": "flake-parts",
         "home-manager": "home-manager",
         "nixos-facter": "nixos-facter",
         "nixos-facter-modules": "nixos-facter-modules",
         "nixpkgs": "nixpkgs",
-        "quickshell": "quickshell",
         "stylix": "stylix"
       }
     },
@@ -428,11 +383,11 @@
         "tinted-zed": "tinted-zed"
       },
       "locked": {
-        "lastModified": 1767903301,
-        "narHash": "sha256-h7HUP2xjbwjXb+DvAxIH6R9G1RdGCAQao8zCw3jj+yY=",
+        "lastModified": 1769202931,
+        "narHash": "sha256-4IZuCMjlWEtS6rVXozVXaJG6QADHVncXC29PLZr6ZB4=",
         "owner": "nix-community",
         "repo": "stylix",
-        "rev": "2b727da436910c4a59b5fd2401609bd5cb7ec64a",
+        "rev": "749285c90e3e35ebe0952c86838f3089abbc7939",
         "type": "github"
       },
       "original": {
@@ -560,11 +515,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1767801790,
-        "narHash": "sha256-QfX6g3Wj2vQe7oBJEbTf0npvC6sJoDbF9hb2+gM5tf8=",
+        "lastModified": 1768158989,
+        "narHash": "sha256-67vyT1+xClLldnumAzCTBvU0jLZ1YBcf4vANRWP3+Ak=",
         "owner": "numtide",
         "repo": "treefmt-nix",
-        "rev": "778a1d691f1ef45dd68c661715c5bf8cbf131c80",
+        "rev": "e96d59dff5c0d7fddb9d113ba108f03c3ef99eca",
         "type": "github"
       },
       "original": {

--- a/flake.lock
+++ b/flake.lock
@@ -80,11 +80,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1769353768,
-        "narHash": "sha256-zI+7cbMI4wMIR57jMjDSEsVb3grapTnURDxxJPYFIW0=",
+        "lastModified": 1771437256,
+        "narHash": "sha256-bLqwib+rtyBRRVBWhMuBXPCL/OThfokA+j6+uH7jDGU=",
         "owner": "numtide",
         "repo": "blueprint",
-        "rev": "c7da5c70ad1c9b60b6f5d4f674fbe205d48d8f6c",
+        "rev": "06ee7190dc2620ea98af9eb225aa9627b68b0e33",
         "type": "github"
       },
       "original": {
@@ -211,11 +211,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1770164260,
-        "narHash": "sha256-mQgOAYWlVJyuyXjZN6yxqXWyODvQI5P/UZUCU7IOuYo=",
+        "lastModified": 1771683283,
+        "narHash": "sha256-WxAEkAbo8dP7qiyPM6VN4ZGAxfuBVlNBNPkrqkrXVEc=",
         "owner": "nix-community",
         "repo": "home-manager",
-        "rev": "4fda26500b4539e0a1e3afba9f0e1616bdad4f85",
+        "rev": "c6ed3eab64d23520bcbb858aa53fe2b533725d4a",
         "type": "github"
       },
       "original": {
@@ -266,11 +266,11 @@
         "treefmt-nix": "treefmt-nix"
       },
       "locked": {
-        "lastModified": 1770178382,
-        "narHash": "sha256-qyb+3p1oUVx3X0Ir8eZ0YUY90C45BrosgZAwqbBUxX4=",
+        "lastModified": 1771474897,
+        "narHash": "sha256-Uh3suNG2251bfHqTqTbBnDLerFaeNWk3p4NIO/URhuc=",
         "owner": "nix-community",
         "repo": "nixos-facter",
-        "rev": "d5c9a1824ae6c4e94e477ab358f2d42835f17c36",
+        "rev": "13db4bd9a10003ddce9f0165365910e06d3c7991",
         "type": "github"
       },
       "original": {
@@ -296,11 +296,11 @@
     },
     "nixpkgs": {
       "locked": {
-        "lastModified": 1770181073,
-        "narHash": "sha256-ksTL7P9QC1WfZasNlaAdLOzqD8x5EPyods69YBqxSfk=",
+        "lastModified": 1771369470,
+        "narHash": "sha256-0NBlEBKkN3lufyvFegY4TYv5mCNHbi5OmBDrzihbBMQ=",
         "owner": "NixOS",
         "repo": "nixpkgs",
-        "rev": "bf922a59c5c9998a6584645f7d0de689512e444c",
+        "rev": "0182a361324364ae3f436a63005877674cf45efb",
         "type": "github"
       },
       "original": {
@@ -383,11 +383,11 @@
         "tinted-zed": "tinted-zed"
       },
       "locked": {
-        "lastModified": 1769978605,
-        "narHash": "sha256-Vjniae6HHJCb9xZLeUOP15aRQXSZuKeeaZFM+gRDCgo=",
+        "lastModified": 1771626923,
+        "narHash": "sha256-Mn6oeKrY+Sw6kH0jK+hp5QQH4MTcqwBRQL/ScZDNcz8=",
         "owner": "nix-community",
         "repo": "stylix",
-        "rev": "ce22070ec5ce6169a6841da31baea33ce930ed38",
+        "rev": "b09847414b50c65788936199918272377f70fb91",
         "type": "github"
       },
       "original": {
@@ -515,11 +515,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1769691507,
-        "narHash": "sha256-8aAYwyVzSSwIhP2glDhw/G0i5+wOrren3v6WmxkVonM=",
+        "lastModified": 1770228511,
+        "narHash": "sha256-wQ6NJSuFqAEmIg2VMnLdCnUc0b7vslUohqqGGD+Fyxk=",
         "owner": "numtide",
         "repo": "treefmt-nix",
-        "rev": "28b19c5844cc6e2257801d43f2772a4b4c050a1b",
+        "rev": "337a4fe074be1042a35086f15481d763b8ddc0e7",
         "type": "github"
       },
       "original": {

--- a/flake.lock
+++ b/flake.lock
@@ -80,11 +80,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1767386128,
-        "narHash": "sha256-BJDu7dIMauO2nYRSL4aI8wDNtEm2KOb7lDKP3hxdrpo=",
+        "lastModified": 1769353768,
+        "narHash": "sha256-zI+7cbMI4wMIR57jMjDSEsVb3grapTnURDxxJPYFIW0=",
         "owner": "numtide",
         "repo": "blueprint",
-        "rev": "0ed984d51a3031065925ab08812a5434f40b93d4",
+        "rev": "c7da5c70ad1c9b60b6f5d4f674fbe205d48d8f6c",
         "type": "github"
       },
       "original": {
@@ -135,11 +135,11 @@
         "nixpkgs-lib": "nixpkgs-lib"
       },
       "locked": {
-        "lastModified": 1768135262,
-        "narHash": "sha256-PVvu7OqHBGWN16zSi6tEmPwwHQ4rLPU9Plvs8/1TUBY=",
+        "lastModified": 1769996383,
+        "narHash": "sha256-AnYjnFWgS49RlqX7LrC4uA+sCCDBj0Ry/WOJ5XWAsa0=",
         "owner": "hercules-ci",
         "repo": "flake-parts",
-        "rev": "80daad04eddbbf5a4d883996a73f3f542fa437ac",
+        "rev": "57928607ea566b5db3ad13af0e57e921e6b12381",
         "type": "github"
       },
       "original": {
@@ -211,11 +211,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1769187349,
-        "narHash": "sha256-clG+nT6I2qxjIgk5WoSDKJyNhzKJs9jzbCujPF2S/yg=",
+        "lastModified": 1770164260,
+        "narHash": "sha256-mQgOAYWlVJyuyXjZN6yxqXWyODvQI5P/UZUCU7IOuYo=",
         "owner": "nix-community",
         "repo": "home-manager",
-        "rev": "082a4cd87c6089d1d9c58ebe52655f9e07245fcb",
+        "rev": "4fda26500b4539e0a1e3afba9f0e1616bdad4f85",
         "type": "github"
       },
       "original": {
@@ -266,11 +266,11 @@
         "treefmt-nix": "treefmt-nix"
       },
       "locked": {
-        "lastModified": 1768967124,
-        "narHash": "sha256-kUCZiVuxw+XEKET8xzm5Wi4Y2JAOr4bQ4+p6ARISoIo=",
+        "lastModified": 1770178382,
+        "narHash": "sha256-qyb+3p1oUVx3X0Ir8eZ0YUY90C45BrosgZAwqbBUxX4=",
         "owner": "nix-community",
         "repo": "nixos-facter",
-        "rev": "c0a9fb6744a76c44a29344699a2a2e73adf59d00",
+        "rev": "d5c9a1824ae6c4e94e477ab358f2d42835f17c36",
         "type": "github"
       },
       "original": {
@@ -296,11 +296,11 @@
     },
     "nixpkgs": {
       "locked": {
-        "lastModified": 1769018530,
-        "narHash": "sha256-MJ27Cy2NtBEV5tsK+YraYr2g851f3Fl1LpNHDzDX15c=",
+        "lastModified": 1770181073,
+        "narHash": "sha256-ksTL7P9QC1WfZasNlaAdLOzqD8x5EPyods69YBqxSfk=",
         "owner": "NixOS",
         "repo": "nixpkgs",
-        "rev": "88d3861acdd3d2f0e361767018218e51810df8a1",
+        "rev": "bf922a59c5c9998a6584645f7d0de689512e444c",
         "type": "github"
       },
       "original": {
@@ -312,11 +312,11 @@
     },
     "nixpkgs-lib": {
       "locked": {
-        "lastModified": 1765674936,
-        "narHash": "sha256-k00uTP4JNfmejrCLJOwdObYC9jHRrr/5M/a/8L2EIdo=",
+        "lastModified": 1769909678,
+        "narHash": "sha256-cBEymOf4/o3FD5AZnzC3J9hLbiZ+QDT/KDuyHXVJOpM=",
         "owner": "nix-community",
         "repo": "nixpkgs.lib",
-        "rev": "2075416fcb47225d9b68ac469a5c4801a9c4dd85",
+        "rev": "72716169fe93074c333e8d0173151350670b824c",
         "type": "github"
       },
       "original": {
@@ -383,11 +383,11 @@
         "tinted-zed": "tinted-zed"
       },
       "locked": {
-        "lastModified": 1769202931,
-        "narHash": "sha256-4IZuCMjlWEtS6rVXozVXaJG6QADHVncXC29PLZr6ZB4=",
+        "lastModified": 1769978605,
+        "narHash": "sha256-Vjniae6HHJCb9xZLeUOP15aRQXSZuKeeaZFM+gRDCgo=",
         "owner": "nix-community",
         "repo": "stylix",
-        "rev": "749285c90e3e35ebe0952c86838f3089abbc7939",
+        "rev": "ce22070ec5ce6169a6841da31baea33ce930ed38",
         "type": "github"
       },
       "original": {
@@ -515,11 +515,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1768158989,
-        "narHash": "sha256-67vyT1+xClLldnumAzCTBvU0jLZ1YBcf4vANRWP3+Ak=",
+        "lastModified": 1769691507,
+        "narHash": "sha256-8aAYwyVzSSwIhP2glDhw/G0i5+wOrren3v6WmxkVonM=",
         "owner": "numtide",
         "repo": "treefmt-nix",
-        "rev": "e96d59dff5c0d7fddb9d113ba108f03c3ef99eca",
+        "rev": "28b19c5844cc6e2257801d43f2772a4b4c050a1b",
         "type": "github"
       },
       "original": {

--- a/flake.nix
+++ b/flake.nix
@@ -3,13 +3,6 @@
     flake-parts.url = "github:hercules-ci/flake-parts";
     nixpkgs.url = "github:NixOS/nixpkgs/nixos-unstable";
 
-    DankMaterialShell = {
-      url = "github:AvengeMedia/DankMaterialShell";
-
-      inputs.nixpkgs.follows = "nixpkgs";
-      inputs.quickshell.follows = "quickshell";
-    };
-
     home-manager = {
       url = "github:nix-community/home-manager";
 
@@ -24,12 +17,6 @@
 
     nixos-facter-modules = {
       url = "github:nix-community/nixos-facter-modules";
-    };
-
-    quickshell = {
-      url = "github:quickshell-mirror/quickshell";
-
-      inputs.nixpkgs.follows = "nixpkgs";
     };
 
     stylix = {

--- a/modules/home-manager/my/programs/dms/config.nix
+++ b/modules/home-manager/my/programs/dms/config.nix
@@ -1,5 +1,4 @@
 {
-  inputs,
   config,
   lib,
   pkgs,
@@ -8,13 +7,6 @@
 let
   cfg = config.my.programs.dms;
   fmt = pkgs.formats.json { };
-
-  inputDms = inputs.DankMaterialShell;
-  inputQs = inputs.quickshell;
-  system = pkgs.stdenv.hostPlatform.system;
-
-  dms-shell = inputDms.packages.${system}.dms-shell;
-  quickshell = inputQs.packages.${system}.default;
 
   # DankMaterialShell's `wallpaperFillMode` option requires sentence casing
   toSentenceCase = string: let
@@ -28,10 +20,10 @@ in {
   #
   # see: https://github.com/AvengeMedia/DankMaterialShell/blob/master/nix/default.nix
   config = lib.mkIf cfg.enable {
-    home.packages = [
-      pkgs.dgop
+    home.packages = with pkgs; [
+      dgop
       dms-shell
-    ] ++ (with pkgs; [
+
       # Needed for brightness functionality
       brightnessctl
 
@@ -47,7 +39,7 @@ in {
 
       # Needed for soundlets
       kdePackages.qtmultimedia
-    ]);
+    ];
 
     # Set some values for Stylix
     my.programs.dms = lib.mkIf config.stylix.enable {
@@ -73,10 +65,10 @@ in {
 
     programs.quickshell = {
       enable = true;
-      package = quickshell;
+      package = pkgs.quickshell;
 
       configs = {
-        dms = "${dms-shell}/share/quickshell/dms";
+        dms = "${pkgs.dms-shell}/share/quickshell/dms";
       };
     };
 
@@ -103,7 +95,7 @@ in {
           "--dereference --no-preserve=all " +
           "${config.xdg.configHome}/DankMaterialShell/default-settings.json " +
           "${config.xdg.configHome}/DankMaterialShell/settings.json";
-        ExecStart = "${lib.getExe dms-shell} run --session";
+        ExecStart = "${lib.getExe pkgs.dms-shell} run --session";
         Restart = "on-failure";
       };
 

--- a/modules/home-manager/my/programs/microsoft-edge/package.nix
+++ b/modules/home-manager/my/programs/microsoft-edge/package.nix
@@ -1,8 +1,25 @@
 {
   microsoft-edge,
 
+  fetchurl,
+
   commandLineArgs ? "",
 }:
-microsoft-edge.override {
+# Some fatal bug was messing with user files in version 145.0.3800.53, which has
+# since been removed from their sources, causing a build failure.
+#
+# The PR that bumped the version has not landed in unstable, so we will override
+# in-place until then.
+#
+# TODO: drop when the relevant PR lands in unstable.
+# see: https://github.com/NixOS/nixpkgs/issues/492012
+(microsoft-edge.overrideAttrs (finalAttrs: prevAttrs: {
+  version = "145.0.3800.70";
+
+  src = fetchurl {
+    url = "https://packages.microsoft.com/repos/edge/pool/main/m/microsoft-edge-stable/microsoft-edge-stable_${finalAttrs.version}-1_amd64.deb";
+    hash = "sha256-gUyh9AD1ntnZb2iLRwKLxy0PxY0Dist73oT9AC2pFQI=";
+  };
+})).override {
   inherit commandLineArgs;
 }

--- a/modules/nixos/documentation/man/module.nix
+++ b/modules/nixos/documentation/man/module.nix
@@ -12,7 +12,12 @@ in {
     # They usually exist on most other distros, and I'm very used to that
     # availability, so let's bring them back here too.
     environment.systemPackages = with pkgs; [
-      linux-manual
+      # Something changed in the `linux-manual` build, and the fix PR hasn't
+      # laned in unstable, so we pull it here.
+      #
+      # TODO: drop this fix once the relevant PR is merged
+      # see: https://github.com/NixOS/nixpkgs/issues/489956
+      (callPackage ./package.nix {})
       man-pages
     ];
   };

--- a/modules/nixos/documentation/man/package.nix
+++ b/modules/nixos/documentation/man/package.nix
@@ -1,0 +1,60 @@
+{
+  lib,
+  stdenv,
+  linuxPackages_latest,
+  python3,
+  man,
+}:
+
+stdenv.mkDerivation {
+  pname = "linux-manual";
+  inherit (linuxPackages_latest.kernel) version src;
+
+  nativeBuildInputs = [ python3 ];
+  nativeInstallCheckInputs = [ man ];
+
+  dontConfigure = true;
+  doInstallCheck = true;
+
+  postPatch = ''
+    patchShebangs --build \
+      tools/docs \
+      scripts/kernel-doc.py
+  '';
+
+  buildPhase = ''
+    runHook preBuild
+
+    # avoid Makefile because it checks for unnecessary Python dependencies
+    KBUILD_BUILD_TIMESTAMP="$(date -u -d "@$SOURCE_DATE_EPOCH")" \
+    tools/docs/sphinx-build-wrapper mandocs
+
+    runHook postBuild
+  '';
+
+  installPhase = ''
+    runHook preInstall
+
+    mkdir -p "$out/share/man"
+    cp -r output/man "$out/share/man/man9"
+
+    runHook postInstall
+  '';
+
+  installCheckPhase = ''
+    runHook preInstallCheck
+
+    # Check for well‐known man page
+    man -M "$out/share/man" -P cat 9 kmalloc >/dev/null
+
+    runHook postInstallCheck
+  '';
+
+  meta = {
+    homepage = "https://kernel.org/";
+    description = "Linux kernel API manual pages";
+    license = lib.licenses.gpl2Only;
+    maintainers = with lib.maintainers; [ mvs ];
+    platforms = lib.platforms.linux;
+  };
+}

--- a/modules/nixos/my/programs/powertop/package.nix
+++ b/modules/nixos/my/programs/powertop/package.nix
@@ -17,7 +17,7 @@
   pciutils,
   zlib,
 
-  xorg,
+  xset,
 }:
 
 stdenv.mkDerivation {
@@ -69,7 +69,7 @@ stdenv.mkDerivation {
 
   postPatch = ''
     substituteInPlace src/main.cpp --replace-fail "/sbin/modprobe" "modprobe"
-    substituteInPlace src/calibrate/calibrate.cpp --replace-fail "/usr/bin/xset" "${lib.getExe xorg.xset}"
+    substituteInPlace src/calibrate/calibrate.cpp --replace-fail "/usr/bin/xset" "${lib.getExe xset}"
     substituteInPlace src/tuning/bluetooth.cpp --replace-fail "/usr/bin/hcitool" "hcitool"
   '';
 }

--- a/modules/nixos/networking/networkmanager/module.nix
+++ b/modules/nixos/networking/networkmanager/module.nix
@@ -8,11 +8,29 @@ let
   cfg = config.networking.networkmanager;
 in {
   config = lib.mkIf cfg.enable {
-    my.persist.directories = [{
-      # TODO: better to persist `system-connections` directory only?
-      path = "/etc/NetworkManager";
-      unique = false;
-    }];
+    my.persist.directories = [
+      {
+        # TODO: better to persist `system-connections` directory only?
+        path = "/etc/NetworkManager";
+        unique = false;
+      }
+      {
+        # Due to NixOS hardening the `wpa_supplicant` daemon by default,
+        # the daemon can no longer arbitrarily read files on the filesystem.
+        #
+        # This has affected my certificates, which are imperatively stored and
+        # configured on a network-basis. To counter this, NixOS exposes the
+        # `/etc/wpa_supplicant` directory, which is where certificates should
+        # go, with the daemon being configured to read this directory.
+        #
+        # Files placed in the aforementioned directory must also be owned by
+        # the `wpa_supplicant` user and group of the same name.
+        #
+        # see: https://github.com/NixOS/nixpkgs/pull/427528
+        path = "/etc/wpa_supplicant";
+        unique = false;
+      }
+    ];
 
     # Enables broadband support, but I don't need this.
     networking.modemmanager.enable = lib.mkForce false;

--- a/pkgs/nix-benchmark/nix/package.nix
+++ b/pkgs/nix-benchmark/nix/package.nix
@@ -25,6 +25,7 @@ stdenvNoCC.mkDerivation {
       nixVersions.nix_2_30
       nixVersions.nix_2_31
       nixVersions.nix_2_32
+      nixVersions.nix_2_33
       nixVersions.git
       lixPackageSets.lix_2_93.lix
       lixPackageSets.lix_2_94.lix

--- a/users/frontear/home/programs/neovim/default.nix
+++ b/users/frontear/home/programs/neovim/default.nix
@@ -127,12 +127,19 @@
           nvim-treesitter.withAllGrammars
         ];
 
-        # Indiscriminantly enable treesitter for all possible filetypes.
-        # This might be a dangerous operation but I am certaintly not
-        # knowledgable enough to know or care.
+        # Automatically enable treesitter for all languages that are supported.
+        #
+        # see: https://github.com/nvim-treesitter/nvim-treesitter/issues/8031#issuecomment-3120353040
         config = ''
           vim.api.nvim_create_autocmd("FileType", {
-            callback = function() vim.treesitter.start() end,
+            callback = function(args)
+              local filetype = vim.bo[args.buf].filetype
+              local lang = vim.treesitter.language.get_lang(filetype)
+
+              if lang and vim.treesitter.language.add(lang) then
+                vim.treesitter.start()
+              end
+            end,
           })
         '';
       }

--- a/users/frontear/home/programs/neovim/default.nix
+++ b/users/frontear/home/programs/neovim/default.nix
@@ -127,14 +127,12 @@
           nvim-treesitter.withAllGrammars
         ];
 
+        # Indiscriminantly enable treesitter for all possible filetypes.
+        # This might be a dangerous operation but I am certaintly not
+        # knowledgable enough to know or care.
         config = ''
-          require("nvim-treesitter").setup({
-            highlight = {
-              enable = true,
-            },
-            indent = {
-              enable = true,
-            },
+          vim.api.nvim_create_autocmd("FileType", {
+            callback = function() vim.treesitter.start() end,
           })
         '';
       }

--- a/users/frontear/home/programs/vscode/default.nix
+++ b/users/frontear/home/programs/vscode/default.nix
@@ -22,6 +22,7 @@
             ms-vscode.cmake-tools
             ms-vscode.cpptools
             myriad-dreamin.tinymist
+            redhat.java
             rust-lang.rust-analyzer
           ]);
 

--- a/users/frontear/home/programs/vscode/extensions.nix
+++ b/users/frontear/home/programs/vscode/extensions.nix
@@ -50,10 +50,10 @@
   }
   {
     arch = "";
-    hash = "sha256-rpYgvo5H1RBviV5L/pfDWqVXIYaZonRiqh4TLFGEODw=";
+    hash = "sha256-Ip9q7BroIVNsxbO/OcZuJWagYsYtV2xJhe0z0NFiR2U=";
     name = "vscode-eslint";
     publisher = "dbaeumer";
-    version = "3.0.19";
+    version = "3.0.21";
   }
   {
     arch = "";
@@ -85,10 +85,10 @@
   }
   {
     arch = "";
-    hash = "sha256-MYPYhSKAxgaZ0UijxU+xiO4HDPLtXGymhN+2YmTev8M=";
+    hash = "sha256-pFd1CTJL3xQ3HHzQs3f4R5f6xlCghNh8Kv+3AT/Qrqo=";
     name = "editorconfig";
     publisher = "editorconfig";
-    version = "0.17.4";
+    version = "0.18.1";
   }
   {
     arch = "";
@@ -99,10 +99,10 @@
   }
   {
     arch = "";
-    hash = "sha256-DkqAxXqZ+YqvPJCjivS3W4dDvoT2xr9KZgi5Rx4elio=";
+    hash = "sha256-mr6AaJC6SqtmZ/mbcCo8M/LUuXovNQak8hWzzeeWdQU=";
     name = "vscode-glsl";
     publisher = "geforcelegend";
-    version = "0.3.3";
+    version = "0.3.4";
   }
   {
     arch = "";
@@ -120,10 +120,10 @@
   }
   {
     arch = "";
-    hash = "sha256-+xnQnrnKlbLaPwSFklmjEbhW5tYFcPlSep6XjHrkWR4=";
+    hash = "sha256-b0RiydB4XqVlr0Q75ioqe5CU4LtlQkwOJe+6Y3KbmZY=";
     name = "applescript";
     publisher = "idleberg";
-    version = "0.28.0";
+    version = "0.29.0";
   }
   {
     arch = "";
@@ -183,10 +183,10 @@
   }
   {
     arch = "";
-    hash = "sha256-Rfsmqo6U6oxTqSz4YKo0OCmM4HVJ2/dXXJl+OliuFkI=";
+    hash = "sha256-WWvo9rzKi2nga0kDLpxAMgO5pJ3Q45qt07hcVdIMfa8=";
     name = "better-perl-syntax";
     publisher = "jeff-hykin";
-    version = "1.0.14";
+    version = "1.0.17";
   }
   {
     arch = "";
@@ -218,10 +218,10 @@
   }
   {
     arch = "";
-    hash = "sha256-MnuFMrP52CcWZTyf2OKSqQ/oqCS3PPivwEIja25N2D0=";
+    hash = "sha256-epdEMPAkSo0IXsd+ozicI8bjPPquDKIzB3ONRUYWwn8=";
     name = "nix-ide";
     publisher = "jnoortheen";
-    version = "0.4.23";
+    version = "0.5.5";
   }
   {
     arch = "";
@@ -281,24 +281,24 @@
   }
   {
     arch = "";
-    hash = "sha256-IPgPE5vM9tzHPioRBZeJs4hqut6t++SjZJlHnz/ismA=";
+    hash = "sha256-xZpK6pJNXnxudauzJihEi9VASRXi89+hn7vfF33qRgY=";
     name = "rainbow-csv";
     publisher = "mechatroner";
-    version = "3.21.0";
+    version = "3.24.1";
   }
   {
     arch = "linux-x64";
-    hash = "sha256-Uf0FoYW+Du97mTA+kgeMJlob7J0JYp8h0pF7Ba8qMWk=";
+    hash = "sha256-jTDzOMa7l3RIZQMnpsp290+ncqar4RL3ikmNGiv4ai0=";
     name = "debugpy";
     publisher = "ms-python";
-    version = "2025.13.2025091201";
+    version = "2025.19.2026012301";
   }
   {
     arch = "";
-    hash = "sha256-Z2R7gUZw1S2iL3KX/3fB326lFzE39v9LGq17Ec2aHCA=";
+    hash = "sha256-s1YBgWrsorAxotNRBR4dgtmLJekTpQO2gzYPQMIxYT8=";
     name = "vscode-pylance";
     publisher = "ms-python";
-    version = "2025.8.2";
+    version = "2025.12.101";
   }
   {
     arch = "";
@@ -316,10 +316,10 @@
   }
   {
     arch = "";
-    hash = "sha256-vP5jMijMIKHUmvSaTX+eEO6Z3dzUCR6S/ZdPxjJHIT8=";
+    hash = "sha256-B2+yaKX/nhBLdeFDffwt4CmeWo+Jr4oMxcWBEaAhRtg=";
     name = "material-icon-theme";
     publisher = "pkief";
-    version = "5.27.0";
+    version = "5.31.0";
   }
   {
     arch = "";
@@ -357,13 +357,6 @@
     version = "0.0.4";
   }
   {
-    arch = "linux-x64";
-    hash = "sha256-spsfZEPYn0dhtv5pIa6yNFMHF+Av+h7Oiib7eiVtjgM=";
-    name = "java";
-    publisher = "redhat";
-    version = "1.46.2025091808";
-  }
-  {
     arch = "";
     hash = "sha256-zgCqKwnP7Fm655FPUkD5GL+/goaplST8507X890Tnhc=";
     name = "scala";
@@ -372,10 +365,10 @@
   }
   {
     arch = "";
-    hash = "sha256-b8VFojeIkplnr48D8el0HeEtN47al/tgqgq52ozjw9M=";
+    hash = "sha256-Dkx4ecPFXTX1ilerkcnUc6Pu/mnXpswYVnHWqR4TYOA=";
     name = "ruby-lsp";
     publisher = "shopify";
-    version = "0.9.32";
+    version = "0.9.33";
   }
   {
     arch = "";
@@ -393,10 +386,10 @@
   }
   {
     arch = "";
-    hash = "sha256-veP2G/5vcaimjd98ur6Mhl4x1NKuvS21oO+HFJLHN+I=";
+    hash = "sha256-sOwVE42dyzYhG0JBV7rjNkMDSS4oE2L9RhfJnC0jvzM=";
     name = "code-spell-checker";
     publisher = "streetsidesoftware";
-    version = "4.2.6";
+    version = "4.4.1";
   }
   {
     arch = "";

--- a/users/frontear/home/programs/vscode/extensions.nix
+++ b/users/frontear/home/programs/vscode/extensions.nix
@@ -120,10 +120,10 @@
   }
   {
     arch = "";
-    hash = "sha256-b0RiydB4XqVlr0Q75ioqe5CU4LtlQkwOJe+6Y3KbmZY=";
+    hash = "sha256-1AuxPO/Pj6Q+1qu4NctDpiGMERreXXNiciLRfN6cDns=";
     name = "applescript";
     publisher = "idleberg";
-    version = "0.29.0";
+    version = "0.29.4";
   }
   {
     arch = "";
@@ -288,17 +288,17 @@
   }
   {
     arch = "linux-x64";
-    hash = "sha256-jTDzOMa7l3RIZQMnpsp290+ncqar4RL3ikmNGiv4ai0=";
+    hash = "sha256-FzH5ADvCyM3DXRMwmJd+exVdqMU7+D+DmV78CzK/vys=";
     name = "debugpy";
     publisher = "ms-python";
-    version = "2025.19.2026012301";
+    version = "2025.19.2026021801";
   }
   {
     arch = "";
-    hash = "sha256-s1YBgWrsorAxotNRBR4dgtmLJekTpQO2gzYPQMIxYT8=";
+    hash = "sha256-82zIUJBgjbBW0R6ExBLXGYYtYxm1vC7bz/3BvP3IIXA=";
     name = "vscode-pylance";
     publisher = "ms-python";
-    version = "2025.12.101";
+    version = "2026.1.1";
   }
   {
     arch = "";
@@ -365,10 +365,10 @@
   }
   {
     arch = "";
-    hash = "sha256-Dkx4ecPFXTX1ilerkcnUc6Pu/mnXpswYVnHWqR4TYOA=";
+    hash = "sha256-RSNcyoyrkVJsFp02aMDDZn51YBKohE+gy+bgHFP45v4=";
     name = "ruby-lsp";
     publisher = "shopify";
-    version = "0.9.33";
+    version = "0.10.0";
   }
   {
     arch = "";
@@ -386,10 +386,10 @@
   }
   {
     arch = "";
-    hash = "sha256-sOwVE42dyzYhG0JBV7rjNkMDSS4oE2L9RhfJnC0jvzM=";
+    hash = "sha256-AAakZeChN5HkhhqbGUWSMXm4Tbq7n+ydWutEDPUdRqQ=";
     name = "code-spell-checker";
     publisher = "streetsidesoftware";
-    version = "4.4.1";
+    version = "4.5.6";
   }
   {
     arch = "";


### PR DESCRIPTION
Hello there and happy new year! A new staging cycle has started up. The last cycle was [2025-12-25 -> 2026-01-08](https://github.com/Frontear/dotfiles/pull/71).

This cycle has had its duration extended to 4 weeks to accommodate for the fact that I am currently busy with school. No particular targets are intended to be achieved, just routine maintenance and fixes to keep my system chugging along.

## Breaking Changes

TODO

## New Features

- feat: remove DMS related inputs, bump flake.lock (957aad69dcfd818b578df2a26c7b7f36a4156815)
- feat: update vscode extensions and fix `redhat.java` extension (38c29ea502863adddb29ec8fce241d7f0cfb1fcc)
- feat: persist `/etc/wpa_supplicant` for network certificates (cce74335c03c189b9062288582a4a91952862178)
- feat: bump flake.lock, fix some broken derivations (dfbea1e1d3d1ea0b69f0513989324222cf65459d)
- feat: update vscode extensions (5604608ad1b33c0f62955441ac31c19c2c682ca0)

## Fixes

- fix: correctly enable highlighting for new treesitter (cb08f07c0694ae7f0cd6a65da7ae926742254c79)
- fix: bump flake.lock, add Nix 2.33 to nix-benchmark (72b926f9f9d26a76ccd81b511964927481402cce)
- fix: treesitter errors on invalid buffers or languages (9185159a7a2da8c5d8f1671e12578a4d6d7d8f0d)
- fix: replace `xorg.xset` -> `xset` (37d56207efad0382fbade1eb50e7282ec4b2d5b3)