### PR TITLE
2026-02-25 -> 2026-03-25

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -135,11 +135,11 @@
         "nixpkgs-lib": "nixpkgs-lib"
       },
       "locked": {
-        "lastModified": 1769996383,
-        "narHash": "sha256-AnYjnFWgS49RlqX7LrC4uA+sCCDBj0Ry/WOJ5XWAsa0=",
+        "lastModified": 1772408722,
+        "narHash": "sha256-rHuJtdcOjK7rAHpHphUb1iCvgkU3GpfvicLMwwnfMT0=",
         "owner": "hercules-ci",
         "repo": "flake-parts",
-        "rev": "57928607ea566b5db3ad13af0e57e921e6b12381",
+        "rev": "f20dc5d9b8027381c474144ecabc9034d6a839a3",
         "type": "github"
       },
       "original": {
@@ -211,11 +211,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1771683283,
-        "narHash": "sha256-WxAEkAbo8dP7qiyPM6VN4ZGAxfuBVlNBNPkrqkrXVEc=",
+        "lastModified": 1772633327,
+        "narHash": "sha256-jl+DJB2DUx7EbWLRng+6HNWW/1/VQOnf0NsQB4PlA7I=",
         "owner": "nix-community",
         "repo": "home-manager",
-        "rev": "c6ed3eab64d23520bcbb858aa53fe2b533725d4a",
+        "rev": "5a75730e6f21ee624cbf86f4915c6e7489c74acc",
         "type": "github"
       },
       "original": {
@@ -266,11 +266,11 @@
         "treefmt-nix": "treefmt-nix"
       },
       "locked": {
-        "lastModified": 1771474897,
-        "narHash": "sha256-Uh3suNG2251bfHqTqTbBnDLerFaeNWk3p4NIO/URhuc=",
+        "lastModified": 1772597558,
+        "narHash": "sha256-bGnGX7QgcoGcm3P6zBQMwgMfyTyTjCNA/0msN54LEoA=",
         "owner": "nix-community",
         "repo": "nixos-facter",
-        "rev": "13db4bd9a10003ddce9f0165365910e06d3c7991",
+        "rev": "8cfebfe0c14658abeab21bf0c9cd89d6e9486ba4",
         "type": "github"
       },
       "original": {
@@ -296,11 +296,11 @@
     },
     "nixpkgs": {
       "locked": {
-        "lastModified": 1771369470,
-        "narHash": "sha256-0NBlEBKkN3lufyvFegY4TYv5mCNHbi5OmBDrzihbBMQ=",
+        "lastModified": 1772542754,
+        "narHash": "sha256-WGV2hy+VIeQsYXpsLjdr4GvHv5eECMISX1zKLTedhdg=",
         "owner": "NixOS",
         "repo": "nixpkgs",
-        "rev": "0182a361324364ae3f436a63005877674cf45efb",
+        "rev": "8c809a146a140c5c8806f13399592dbcb1bb5dc4",
         "type": "github"
       },
       "original": {
@@ -312,11 +312,11 @@
     },
     "nixpkgs-lib": {
       "locked": {
-        "lastModified": 1769909678,
-        "narHash": "sha256-cBEymOf4/o3FD5AZnzC3J9hLbiZ+QDT/KDuyHXVJOpM=",
+        "lastModified": 1772328832,
+        "narHash": "sha256-e+/T/pmEkLP6BHhYjx6GmwP5ivonQQn0bJdH9YrRB+Q=",
         "owner": "nix-community",
         "repo": "nixpkgs.lib",
-        "rev": "72716169fe93074c333e8d0173151350670b824c",
+        "rev": "c185c7a5e5dd8f9add5b2f8ebeff00888b070742",
         "type": "github"
       },
       "original": {
@@ -383,11 +383,11 @@
         "tinted-zed": "tinted-zed"
       },
       "locked": {
-        "lastModified": 1771626923,
-        "narHash": "sha256-Mn6oeKrY+Sw6kH0jK+hp5QQH4MTcqwBRQL/ScZDNcz8=",
+        "lastModified": 1772296853,
+        "narHash": "sha256-pAtzPsgHRKw/2Kv8HgAjSJg450FDldHPWsP3AKG/Xj0=",
         "owner": "nix-community",
         "repo": "stylix",
-        "rev": "b09847414b50c65788936199918272377f70fb91",
+        "rev": "c4b8e80a1020e09a1f081ad0f98ce804a6e85acf",
         "type": "github"
       },
       "original": {

--- a/modules/shared/nix/config/nixos/default.nix
+++ b/modules/shared/nix/config/nixos/default.nix
@@ -28,6 +28,13 @@ in {
     {
       # Use github:viperML/nh as our "nix wrapper" program.
       programs.nh.enable = true;
+      # TODO: remove when the issue regarding specialisations not being setup
+      # is fixed upstream.
+      #
+      # see: https://github.com/nix-community/nh/issues/586
+      programs.nh.package = pkgs.nh.override {
+        nh-unwrapped = pkgs.callPackage ./nh-unwrapped-package.nix {};
+      };
 
       # Set the system Nix package to our custom wrapper, which provides
       # instant access to all `pkgs` and `lib` attributes.

--- a/modules/shared/nix/config/nixos/nh-unwrapped-package.nix
+++ b/modules/shared/nix/config/nixos/nh-unwrapped-package.nix
@@ -1,0 +1,73 @@
+# from: https://github.com/NixOS/nixpkgs/blob/3fd978b5845d7475033f46cee2ed400f9300133d/pkgs/by-name/nh/nh-unwrapped/package.nix
+{
+  stdenv,
+  lib,
+  rustPlatform,
+  installShellFiles,
+  fetchFromGitHub,
+  fetchpatch,
+  nix-update-script,
+  buildPackages,
+}:
+rustPlatform.buildRustPackage (finalAttrs: {
+  pname = "nh-unwrapped";
+  version = "4.2.0"; # Did you remove the patch below (and this comment)?
+
+  src = fetchFromGitHub {
+    owner = "nix-community";
+    repo = "nh";
+    tag = "v${finalAttrs.version}";
+    hash = "sha256-6n5SVO8zsdVTD691lri7ZcO4zpqYFU8GIvjI6dbxkA8=";
+  };
+
+  patches = [
+    (fetchpatch {
+      url = "https://github.com/nix-community/nh/commit/8bf323483166797a204579a43ed8810113eb128c.patch";
+      hash = "sha256-hg0LgDPjiPWR+1DRzqORv6QPlrds7ys4PTDXFw6PUoI=";
+    })
+  ];
+
+  strictDeps = true;
+
+  nativeBuildInputs = [
+    installShellFiles
+  ];
+
+  postInstall = lib.optionalString (stdenv.hostPlatform.emulatorAvailable buildPackages) (
+    let
+      emulator = stdenv.hostPlatform.emulator buildPackages;
+    in
+    ''
+      mkdir completions
+
+      for shell in bash zsh fish; do
+        NH_NO_CHECKS=1 ${emulator} $out/bin/nh completions $shell > completions/nh.$shell
+      done
+
+      installShellCompletion completions/*
+
+      cargo xtask man --out-dir gen
+      installManPage gen/nh.1
+    ''
+  );
+
+  cargoHash = "sha256-cxZsePgraYevuYQSi3hTU2EsiDyn1epSIcvGi183fIU=";
+
+  passthru.updateScript = nix-update-script { };
+
+  env.NH_REV = finalAttrs.src.tag;
+
+  meta = {
+    changelog = "https://github.com/nix-community/nh/blob/${finalAttrs.version}/CHANGELOG.md";
+    description = "Yet another nix cli helper";
+    homepage = "https://github.com/nix-community/nh";
+    license = lib.licenses.eupl12;
+    mainProgram = "nh";
+    maintainers = with lib.maintainers; [
+      NotAShelf
+      mdaniels5757
+      viperML
+      midischwarz12
+    ];
+  };
+})

--- a/nix/templates/parts/envrc
+++ b/nix/templates/parts/envrc
@@ -1,0 +1,17 @@
+# If an existing lock file isn't found, one is created which attempts to sync
+# the revisions of `flake-parts` and `nixpkgs` for this local flake with the
+# revisions found in the system registry.
+#
+# Thank you @waffle8946 for this snippet.
+# see: https://discourse.nixos.org/t/using-the-global-registry-to-create-the-initial-flake-lock/76098/2
+if [ ! -f $PWD/flake.lock ]; then
+  FLAKE_PARTS_REF=$(nix flake metadata flake-parts --json | nix run nixpkgs#jq -- -r ".locked.rev")
+  NIXPKGS_REF=$(nix flake metadata nixpkgs --json | nix run nixpkgs#jq -- -r ".locked.rev")
+
+  nix flake update \
+    --override-input flake-parts github:hercules-ci/flake-parts/$FLAKE_PARTS_REF \
+    --override-input nixpkgs github:NixOS/nixpkgs/$NIXPKGS_REF
+fi
+
+watch_dir nix
+use flake

--- a/nix/templates/rust/envrc
+++ b/nix/templates/rust/envrc
@@ -1,0 +1,19 @@
+# If an existing lock file isn't found, one is created which attempts to sync
+# the revisions of `flake-parts` and `nixpkgs` for this local flake with the
+# revisions found in the system registry.
+#
+# Thank you @waffle8946 for this snippet.
+# see: https://discourse.nixos.org/t/using-the-global-registry-to-create-the-initial-flake-lock/76098/2
+if [ ! -f $PWD/flake.lock ]; then
+  FLAKE_PARTS_REF=$(nix flake metadata flake-parts --json | nix run nixpkgs#jq -- -r ".locked.rev")
+  NIXPKGS_REF=$(nix flake metadata nixpkgs --json | nix run nixpkgs#jq -- -r ".locked.rev")
+
+  nix flake update \
+    --override-input flake-parts github:hercules-ci/flake-parts/$FLAKE_PARTS_REF \
+    --override-input nixpkgs github:NixOS/nixpkgs/$NIXPKGS_REF
+fi
+
+export CARGO_HOME="$(direnv_layout_dir)/cargo"
+
+watch_dir nix
+use flake

--- a/users/frontear/home/programs/vscode/extensions.nix
+++ b/users/frontear/home/programs/vscode/extensions.nix
@@ -393,6 +393,13 @@
   }
   {
     arch = "";
+    hash = "sha256-QSlmYzV7N/k8VhSOPfRqrPHp++6wVqgjnX9kAiyH+jo=";
+    name = "code-spell-checker-canadian-english";
+    publisher = "streetsidesoftware";
+    version = "1.1.31";
+  }
+  {
+    arch = "";
     hash = "sha256-7+Yo6X+t56tnZzepBKEo5hJdgLxiF3+83hSFqpkhVpA=";
     name = "sass-indented";
     publisher = "syler";

--- a/users/frontear/home/programs/vscode/settings.nix
+++ b/users/frontear/home/programs/vscode/settings.nix
@@ -53,6 +53,12 @@
 
   "cSpell.language" = "en,en-CA";
 
+  # Automatically reload gradle project when changed.
+  "java.configuration.updateBuildConfiguration" = "automatic";
+  # Extension gets confused when multiple *.java files exist and misconfigures
+  # the workspace, so it's better to set it manually.
+  "java.import.projectSelection" = "manual";
+
   "nix.enableLanguageServer" = true;
   "nix.serverPath" = "nixd";
 

--- a/users/frontear/home/programs/vscode/settings.nix
+++ b/users/frontear/home/programs/vscode/settings.nix
@@ -1,4 +1,6 @@
 {
+  # ============================= VSCode Settings =============================
+
   "editor.accessibilitySupport" = "off";
   "editor.cursorBlinking" = "phase";
   "editor.cursorSmoothCaretAnimation" = "on";
@@ -47,7 +49,9 @@
   "workbench.secondarySideBar.defaultVisibility" = "hidden"; # stupid LLM chat
   "workbench.startupEditor" = "newUntitledFile";
 
-  # Extensions
+  # ============================ VSCode Extensions ============================
+
+  "cSpell.language" = "en,en-CA";
 
   "nix.enableLanguageServer" = true;
   "nix.serverPath" = "nixd";


### PR DESCRIPTION
Hello there! A new staging cycle has been started up. The last cycle was [2026-01-23 -> 2026-02-20](https://github.com/Frontear/dotfiles/pull/72).

As per the convention set forth by the previous cycle, this one has its duration extended to 4 weeks to accommodate my priorities to school. Small maintenance and upkeep of the system is the main goal of this cycle, with some (hopefully) minor updates to existing systems to make them work smoother.

## Breaking Changes

TODO

## New Features

- feat: add support for Canadian English to VSCode cSpell (72e83b531a210f592a6bf81b13cca5e0aafbc393)
- feat: bump flake.lock (1b9a942502300d5f9f8a830b54abd2f08027e5a3)
- feat: configure Java extension to stop misbehaving (3789360b6c9898894e84f94e6d96534c7349a917)
- feat: add placeholder envrc files for templates (f2109ecb4e8402b0f85618576772a0c810da35af)

## Fixes

- fix: rollback nh to avoid specialisation issue (c01b5b8551410f66b5a14a946be760cd16e30604)